### PR TITLE
fix(oidc): stop redirect loop by using SameSite=Lax session cookie

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,6 +42,7 @@ app.use((req, res, next) => {
 app.use(express.static('public', { index: false }));
 
 // Session config
+const oidcEnabled = process.env.OIDC_ENABLED === 'true';
 const sessionMiddleware = session({
   secret: process.env.SESSION_SECRET || 'dev-secret-change-in-production',
   resave: false,
@@ -49,7 +50,8 @@ const sessionMiddleware = session({
   cookie: { 
     secure: process.env.NODE_ENV === 'production',
     httpOnly: true,
-    sameSite: 'strict',
+    // OIDC auth redirects are cross-site; Strict drops session cookie on callback and causes loops.
+    sameSite: oidcEnabled ? 'lax' : 'strict',
     maxAge: 24 * 60 * 60 * 1000
   }
 });


### PR DESCRIPTION
## Why
OIDC callback is a cross-site navigation from `sso.jory.dev` back to `miso-chat.jory.dev`.
With `SameSite=Strict`, the session cookie holding OIDC state is dropped on callback, which causes auth failure and repeated `/login -> /auth/oidc` redirects.

## Change
- Set session cookie `sameSite` to `lax` when `OIDC_ENABLED=true`
- Keep `sameSite=strict` for local username/password mode

## Scope
- OIDC + chat only
- No UI/features added
