### PR TITLE
fix(oidc): preserve trailing slash in issuer derived from provider URL

### DIFF
--- a/server.js
+++ b/server.js
@@ -82,7 +82,7 @@ if (process.env.OIDC_ENABLED !== 'true') {
 } else {
   const providerUrl = (process.env.OIDC_PROVIDER_URL || '').trim();
   const providerIssuer = providerUrl
-    ? providerUrl.replace(/\/\.well-known\/openid-configuration\/?$/, '')
+    ? providerUrl.replace(/\/\.well-known\/openid-configuration\/?$/, '/')
     : '';
 
   const issuer = providerIssuer || process.env.OIDC_ISSUER;


### PR DESCRIPTION
## Why
Authentik's app well-known metadata returns issuer with a trailing slash:
`https://sso.jory.dev/application/o/miso-chat/`

Our code derived issuer from `OIDC_PROVIDER_URL` without the trailing slash, which can cause issuer mismatch during callback validation and trigger login redirect loops.

## Change
- Preserve trailing slash when deriving issuer from provider URL.

## Scope
- OIDC only
- no feature changes
