### PR TITLE
Fix #67: avoid full chat refresh and scroll jump on history poll

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1237,7 +1237,10 @@
 
                 if (!Array.isArray(messages)) return;
 
-                if (messages.length < historyMessageKeys.size) {
+                const anyOverlap = messages.some((msg, index) => historyMessageKeys.has(historyMessageKey(msg, index)));
+                const likelyReset = messages.length < historyMessageKeys.size && !anyOverlap;
+
+                if (likelyReset) {
                     renderHistory(messages);
                     renderPendingForSession(sessionKey);
                     setOnlineState(true, queueStatusText(sessionKey));


### PR DESCRIPTION
Only trigger a full re-render when the server history looks like a real reset (shorter list and no overlap with known message keys). Normal polls now only append new messages, so the list and scroll position stay stable.

Closes #67 