### PR TITLE
fix: ensure typing indicator is visible (#82)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -159,6 +159,7 @@
             gap: 16px;
             -webkit-overflow-scrolling: touch;
             scroll-behavior: smooth;
+            min-height: 0; /* Important for flex child to shrink */
         }
         
         .message {
@@ -644,7 +645,9 @@
         /* Typing indicator */
         .typing {
             display: none;
-            padding: 0 16px 12px;
+            padding: 8px 16px;
+            z-index: 10;
+            position: relative;
         }
         
         .typing.active {


### PR DESCRIPTION
## Summary
Fix typing indicator not showing up.

## Changes
- Add z-index and position relative to typing indicator
- Add min-height: 0 to messages container for proper flex behavior

## Testing
- Send a message
- Wait for response
- Verify typing indicator appears during processing