### PR TITLE
fix: run build workflow on PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
The build workflow only ran on push to main, not on pull requests. This caused auto-merge to fail because the required merge job never ran for PRs.