### PR TITLE
fix: improve emoji picker positioning and mobile layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -557,10 +557,28 @@
             padding: calc(var(--safe-area-bottom) + 12px) 16px 16px;
             border-top: 1px solid var(--border);
             display: flex;
-            gap: 12px;
+            gap: 8px;
             flex-shrink: 0;
             -webkit-backdrop-filter: blur(20px);
             backdrop-filter: blur(20px);
+        }
+
+        @media (max-width: 767px) {
+            .input-area {
+                gap: 4px;
+                padding-bottom: calc(var(--safe-area-bottom) + 8px);
+            }
+            
+            .emoji-btn {
+                width: 40px;
+                height: 40px;
+                padding: 0;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 18px;
+                border-radius: 50%;
+            }
         }
         
         .input-wrapper {
@@ -595,12 +613,12 @@
         }
         
         .emoji-picker {
-            position: absolute;
-            bottom: 60px;
+            position: fixed;
+            bottom: 70px;
             right: 10px;
             background: var(--bg-secondary);
             border: 1px solid var(--border);
-            border-radius: 8px;
+            border-radius: 12px;
             padding: 8px;
             display: none;
             grid-template-columns: repeat(6, 1fr);
@@ -609,6 +627,20 @@
             max-height: 200px;
             overflow-y: auto;
             z-index: 100;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+        }
+
+        @media (max-width: 767px) {
+            .emoji-picker {
+                position: fixed;
+                bottom: 70px;
+                left: 10px;
+                right: 10px;
+                max-width: none;
+                width: calc(100% - 20px);
+                max-height: 240px;
+                grid-template-columns: repeat(8, 1fr);
+            }
         }
 
         @media (min-width: 768px) {
@@ -654,6 +686,14 @@
         
         .send-btn:active {
             transform: scale(0.92);
+        }
+
+        @media (max-width: 767px) {
+            .send-btn {
+                width: 44px;
+                height: 44px;
+                font-size: 18px;
+            }
         }
         
         .send-btn:disabled {


### PR DESCRIPTION
Fixes #103

## Changes
- Reduce input area gaps on mobile (12px → 8px default, 4px on mobile)
- Make emoji button smaller and circular on mobile (40px)
- Change emoji picker to fixed positioning for better mobile behavior
- Make emoji picker full-width on mobile with 8-column grid
- Add box shadow to emoji picker for better visibility
- Reduce send button size on mobile (52px → 44px)
- Improve bottom padding on mobile input area

## Testing
- [ ] Test on mobile viewport (< 768px)
- [ ] Test on desktop viewport (≥ 768px)
- [ ] Verify emoji picker opens/closes correctly
- [ ] Verify emoji picker fits within viewport