### PR TITLE
fix: infer agent name from OpenClaw session metadata (#64)

### DIFF
--- a/server.js
+++ b/server.js
@@ -826,12 +826,14 @@ app.get('/api/sessions', isAuthenticated, async (req, res) => {
     const payload = unwrapToolResult(result);
     const sessions = (payload?.sessions || []).map((s) => ({
       sessionKey: s.key || s.sessionKey || s.sessionId,
-      displayName: s.displayName || s.key || s.sessionKey,
+      displayName: s.displayName || s.agentName || s.key || s.sessionKey,
       updatedAt: s.updatedAt,
       kind: s.kind,
       channel: s.channel,
       lastMessage: s.lastMessage,
       title: s.derivedTitle || s.title,
+      agentId: s.agentId,
+      agentName: s.agentName,
     }));
 
     const deduped = [];


### PR DESCRIPTION
## Summary

- Extract  from OpenClaw session metadata for  fallback
- Add  and  fields to session API response
- Fix duplicate  in fallback chain

This allows the frontend to display the actual agent name from OpenClaw instead of deriving it from the session key.