### PR TITLE
fix: upload APK as artifact for manual dispatch

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -32,14 +32,19 @@ jobs:
         run: npm ci
         
       - name: Build Debug APK
-        run: |
-          npx cap sync android
-          cd android
-          ./gradlew assembleDebug
+        run: npx cap sync android && npx cap build android
         
-      - name: Upload Release Asset
+      - name: Upload to Release
+        if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1
         with:
           files: android/app/build/outputs/apk/debug/*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Upload Artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: miso-chat-debug.apk
+          path: android/app/build/outputs/apk/debug/*.apk


### PR DESCRIPTION
When workflow is manually triggered, upload APK as artifact instead of failing