### PR TITLE
fix: upload APK as artifact for manual workflow runs

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -37,9 +37,17 @@ jobs:
           cd android
           ./gradlew assembleDebug
         
-      - name: Upload Release Asset
+      - name: Upload to Release
+        if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1
         with:
           files: android/app/build/outputs/apk/debug/*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Upload Artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: miso-chat-debug.apk
+          path: android/app/build/outputs/apk/debug/*.apk


### PR DESCRIPTION
Upload as artifact for workflow_dispatch, upload to release for published releases