### PR TITLE
fix: desktop replies should appear without manual refresh

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1722,7 +1722,6 @@
         }
 
         function startHistoryPolling() {
-            if (sseConnected) return;
             stopHistoryPolling();
             historyPollTimer = setInterval(() => {
                 pollSessionHistory();
@@ -1988,7 +1987,6 @@
 
             eventSource.onopen = () => {
                 sseConnected = true;
-                stopHistoryPolling();
                 console.log('📡 SSE connected');
             };
 
@@ -2126,6 +2124,7 @@
                     }
                     
                     // Remove typing indicator after getting response
+                    await pollSessionHistory();
                 }
             } catch (error) {
                 console.error('Send error:', error);


### PR DESCRIPTION
## Summary
Fixes regression where replies were only visible after manually pressing Refresh.

## Root cause
History polling was disabled whenever SSE connected. In current UI flow, SSE does not append assistant replies directly, so disabling polling prevented new replies from rendering.

## Fix
- Keep history polling active even when SSE is connected
- Trigger a `pollSessionHistory()` after successful send response handling for faster UI sync

## Result
Desktop web UI should show assistant replies automatically without requiring manual refresh.
