### PR TITLE
fix: /status render as left-aligned OpenClaw text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2171,10 +2171,13 @@
 
                             const text =
                                 (typeof data?.text === 'string' && data.text.trim())
+                                || (typeof data?.payload?.statusText === 'string' && data.payload.statusText.trim())
                                 || (typeof data?.payload?.text === 'string' && data.payload.text.trim())
-                                || JSON.stringify(data?.payload || data, null, 2);
+                                || (typeof data?.payload?.summary === 'string' && data.payload.summary.trim())
+                                || 'OpenClaw status unavailable.';
 
-                            addMessage('system', text);
+                            // Render like assistant output (left-aligned), not centered system card.
+                            addMessage('miso', text);
                         } catch (error) {
                             addMessage('system', `OpenClaw status failed: ${error?.message || 'network error'}`);
                         }

--- a/server.js
+++ b/server.js
@@ -264,7 +264,12 @@ app.get('/api/openclaw-status', isAuthenticated, async (req, res) => {
     });
 
     const payload = unwrapToolResult(result);
-    const text = payload?.text || payload?.summary || result?.text || '';
+    const text =
+      payload?.statusText
+      || payload?.text
+      || payload?.summary
+      || result?.text
+      || '';
 
     res.json({ ok: true, payload, text });
   } catch (error) {


### PR DESCRIPTION
Follow-up to #181 (merged before latest formatting fix).

## Fix
- Prefer `statusText` in `/api/openclaw-status` response
- Render `/status` output as assistant-style left-aligned text (not centered system JSON)

This restores visual parity with native OpenClaw status output.
