### PR TITLE
feat: make /stop call OpenClaw abort directly

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2151,7 +2151,7 @@
             
             switch (command) {
                 case 'help':
-                    addMessage('system', 'Available commands:\n- /help - Show this message\n- /clear - Clear chat history\n- /status - Show OpenClaw session status\n- /stop - Stop current queue processing\n- /backend <url> - Set API base URL (empty to reset)\n- /logout - Sign out and clear local session state');
+                    addMessage('system', 'Available commands:\n- /help - Show this message\n- /clear - Clear chat history\n- /status - Show OpenClaw session status\n- /stop - Abort active OpenClaw run for this session\n- /backend <url> - Set API base URL (empty to reset)\n- /logout - Sign out and clear local session state');
                     break;
                 case 'clear':
                     clearChatDisplay();
@@ -2194,9 +2194,33 @@
                     break;
                 }
                 case 'stop':
-                    sendQueue = sendQueue.filter(item => item.sessionKey !== currentSessionKey);
-                    savePendingQueue(sendQueue);
-                    addMessage('system', 'Queue cleared for this session.');
+                    (async () => {
+                        if (!currentSessionKey) {
+                            addMessage('system', 'No active session selected.');
+                            return;
+                        }
+
+                        try {
+                            const response = await apiFetch('/api/openclaw-stop', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ sessionKey: currentSessionKey }),
+                            });
+                            const data = await response.json();
+
+                            if (!response.ok || data?.ok === false) {
+                                addMessage('system', `OpenClaw stop failed: ${data?.error || 'unknown error'}`);
+                                return;
+                            }
+
+                            // Optional local queue cleanup so stale queued items do not restart work.
+                            sendQueue = sendQueue.filter(item => item.sessionKey !== currentSessionKey);
+                            savePendingQueue(sendQueue);
+                            addMessage('system', 'Abort signal sent to OpenClaw for this session.');
+                        } catch (error) {
+                            addMessage('system', `OpenClaw stop failed: ${error?.message || 'network error'}`);
+                        }
+                    })();
                     break;
                 case 'logout':
                     logout();

--- a/server.js
+++ b/server.js
@@ -278,6 +278,37 @@ app.get('/api/openclaw-status', isAuthenticated, async (req, res) => {
   }
 });
 
+// POST /api/openclaw-stop - Abort current OpenClaw chat run for a session
+app.post('/api/openclaw-stop', isAuthenticated, async (req, res) => {
+  try {
+    const sessionKey = typeof req.body?.sessionKey === 'string' && req.body.sessionKey.trim()
+      ? req.body.sessionKey.trim()
+      : undefined;
+
+    if (!sessionKey) {
+      return res.status(400).json({ ok: false, error: 'sessionKey is required' });
+    }
+
+    // Preferred path: persistent WS method (matches OpenClaw runtime API)
+    if (gatewayWsManager?.isConnected?.()) {
+      try {
+        const frame = await gatewayWsManager.send('chat.abort', { sessionKey }, 10);
+        return res.json({ ok: true, frame });
+      } catch (wsErr) {
+        console.warn('chat.abort via WS failed, trying tool fallback:', wsErr.message);
+      }
+    }
+
+    // Fallback for environments where WS abort path is unavailable
+    const result = await gatewayInvoke('chat_abort', { sessionKey });
+    const payload = unwrapToolResult(result);
+    return res.json({ ok: true, payload });
+  } catch (error) {
+    console.error('Error aborting OpenClaw run:', error.message);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+});
+
 /**
  * Infer a readable agent name from session key metadata
  * Handles formats like: agent:main:main, agent:chatgpt:thread-123, etc.


### PR DESCRIPTION
## Summary
Follow-up PR (after #181 auto-merge) to make `/stop` bypass local miso-chat behavior and call OpenClaw directly.

## What changed
- Added `POST /api/openclaw-stop` backend route:
  - requires `sessionKey`
  - preferred path: WS `chat.abort`
  - fallback path: tool invoke `chat_abort`
- Updated frontend `/stop` slash command:
  - calls `/api/openclaw-stop` immediately (no queue path)
  - reports OpenClaw abort success/failure to user
  - still clears local queued items for the session to avoid stale replay
- Updated `/help` text to describe `/stop` accurately.

## Why
User expectation is that slash commands act like OpenClaw commands. `/stop` should abort active OpenClaw work, not only clear local queue.
