### PR TITLE
fix: close emoji picker when sending a message

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2227,7 +2227,10 @@
             const raw = text ?? messageInput.value ?? '';
             const messageText = String(raw).trim();
             if (!messageText) return;
-            
+
+            // Close emoji picker when sending a message
+            emojiPicker.classList.remove('open');
+
             // Handle slash commands immediately (bypass queue)
             if (messageText.startsWith('/')) {
                 handleSlashCommand(messageText);


### PR DESCRIPTION
Closes the emoji picker automatically when a message is sent. This improves UX by ensuring the picker doesn't stay open and obstruct the chat view after the user sends a message.