### PR TITLE
fix: keep typing indicator visible while queued messages process

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -947,6 +947,7 @@
         let historyPollTimer = null;
         let historyPollInFlight = false;
         let sseConnected = false;
+        let sseTypingActive = false;
         let historyMessageKeys = new Set();
         let localAssistantEchoes = new Map();
 
@@ -1654,6 +1655,11 @@
             return queued > 0 ? `Online · queue ${queued}` : 'Online';
         }
 
+        function updateTypingIndicator() {
+            const hasQueued = currentSessionKey ? queueCountForSession(currentSessionKey) > 0 : false;
+            typingIndicator.classList.toggle('active', sseTypingActive || sending || hasQueued);
+        }
+
         async function refreshBackendHealth() {
             try {
                 const response = await apiFetch('/api/health');
@@ -1991,6 +1997,7 @@
 
             eventSource.onopen = () => {
                 sseConnected = true;
+                updateTypingIndicator();
                 console.log('📡 SSE connected');
             };
 
@@ -2001,8 +2008,14 @@
                     const eventData = payload?.data;
                     if (!eventType) return;
 
-                    if (eventType === 'typing.start') typingIndicator.classList.add('active');
-                    if (eventType === 'typing.stop') typingIndicator.classList.remove('active');
+                    if (eventType === 'typing.start') {
+                        sseTypingActive = true;
+                        updateTypingIndicator();
+                    }
+                    if (eventType === 'typing.stop') {
+                        sseTypingActive = false;
+                        updateTypingIndicator();
+                    }
                     if (eventType === 'error' && eventData?.message) {
                         addMessage('system', `Gateway error: ${eventData.message}`);
                     }
@@ -2013,6 +2026,8 @@
 
             eventSource.onerror = async () => {
                 sseConnected = false;
+                sseTypingActive = false;
+                updateTypingIndicator();
                 console.warn('📡 SSE connection error, reconnecting...');
                 startHistoryPolling();
                 await refreshBackendHealth();
@@ -2043,12 +2058,16 @@
 
                 if (sessions.length === 0) {
                     stopHistoryPolling();
+                    sseTypingActive = false;
+                    updateTypingIndicator();
                     setOnlineState(false, 'No sessions');
                     return;
                 }
 
                 const { selected, notice } = resolvePreferredSession(sessions);
                 if (!selected?.sessionKey) {
+                    sseTypingActive = false;
+                    updateTypingIndicator();
                     setOnlineState(false, 'No sessions');
                     return;
                 }
@@ -2057,6 +2076,8 @@
             } catch (error) {
                 console.error('Error loading sessions:', error);
                 stopHistoryPolling();
+                sseTypingActive = false;
+                updateTypingIndicator();
                 sessionSelect.innerHTML = '<option value="">Error</option>';
                 setOnlineState(false, 'Session load failed');
             }
@@ -2066,6 +2087,7 @@
             if (!sessionKey) return;
 
             currentSessionKey = sessionKey;
+            sseTypingActive = false;
             localStorage.setItem(SESSION_STORAGE_KEY, sessionKey);
             sessionSelect.value = sessionKey;
             const selectedMeta = sessionMetaByKey.get(sessionKey);
@@ -2073,6 +2095,7 @@
             assistantNameEl.textContent = sessionAssistant;
             messageInput.placeholder = `Message ${sessionAssistant}...`;
             setOnlineState(true, 'Loading history...');
+            updateTypingIndicator();
 
             try {
                 const messages = await fetchHistoryMessages(sessionKey);
@@ -2103,6 +2126,7 @@
             sending = true;
             const [next] = sendQueue.splice(nextIndex, 1);
             savePendingQueue(sendQueue);
+            updateTypingIndicator();
 
             setOnlineState(true, queueStatusText(currentSessionKey));
 
@@ -2138,6 +2162,7 @@
             } finally {
                 sending = false;
                 const remaining = queueCountForSession(currentSessionKey);
+                updateTypingIndicator();
                 setOnlineState(true, queueStatusText(currentSessionKey));
                 if (remaining > 0) processQueue();
             }
@@ -2260,6 +2285,7 @@
                 createdAt,
             });
             savePendingQueue(sendQueue);
+            updateTypingIndicator();
             processQueue();
         }
 


### PR DESCRIPTION
## Summary
- keep typing indicator active while messages are queued/sending
- combine SSE typing events with local queue/sending state so indicator does not disappear early
- reset stale SSE typing state on session changes and SSE errors

## Why
This is a small follow-up to the typing indicator work from MEMORY.md (Typing indicator #165) so users still see activity when queued messages are processing.

## Testing
- npm test
