### PR TITLE
fix: register service worker for PWA shell (#203)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1612,6 +1612,17 @@
             return fetch(apiUrl(path), options);
         }
 
+        async function registerServiceWorker() {
+            if (!('serviceWorker' in navigator)) return;
+
+            try {
+                await navigator.serviceWorker.register('/sw.js');
+                console.log('✅ Service worker registered');
+            } catch (error) {
+                console.warn('Service worker registration failed:', error);
+            }
+        }
+
         async function ensureMobileBackendConfigured() {
             const hasBackendInQuery = new URLSearchParams(window.location.search).has('backend');
             if (hasBackendInQuery) return;
@@ -2818,6 +2829,7 @@
             resizeMessageInput();
             setOnlineState(false, 'Connecting...');
             await ensureMobileBackendConfigured();
+            await registerServiceWorker();
             await loadConfig();
             await loadSessions();
             connectEventSource();

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,49 @@
+const CACHE_NAME = 'miso-chat-shell-v1';
+const APP_SHELL = [
+  '/',
+  '/index.html',
+  '/login.html',
+  '/manifest.json',
+  '/favicon.ico',
+  '/icon-192.png',
+  '/icon-512.png',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)),
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(
+      keys
+        .filter((key) => key !== CACHE_NAME)
+        .map((key) => caches.delete(key)),
+    )),
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
+
+      return fetch(event.request).then((response) => {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+        return response;
+      }).catch(async () => {
+        if (event.request.mode === 'navigate') {
+          return caches.match('/index.html');
+        }
+        throw new Error('Network unavailable and no cached response.');
+      });
+    }),
+  );
+});


### PR DESCRIPTION
## Summary
This PR adds a lightweight service worker registration to the web client and introduces a root-scoped service worker file for app-shell caching. It enables baseline offline/installability behavior for the chat UI as part of the PWA work.

## Changes
- register /sw.js on app startup when service workers are supported
- add public/sw.js with app-shell pre-cache + runtime cache fallback for navigation requests

Fixes #203