### PR TITLE
fix: resolve Android APK build failure on AGP 9

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -19,7 +19,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix Android release config to use the supported default ProGuard file for AGP 9+
- replace `proguard-android.txt` with `proguard-android-optimize.txt`

## Why
GitHub Actions run `Build Debug APK` was failing with:
- `getDefaultProguardFile('proguard-android.txt') is no longer supported`

This update matches current Android Gradle Plugin requirements and unblocks APK builds.

## Validation
- Verified failing run logs for job `65766890561` from run `22685401601`
- Applied fix in `android/app/build.gradle`
