### PR TITLE
fix: prevent extra spaces on emoji shortcode insert (#173)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1806,8 +1806,13 @@
             const { emoji } = activeShortcodeResults[index];
             const before = messageInput.value.slice(0, activeShortcode.start);
             const after = messageInput.value.slice(activeShortcode.end);
-            const nextValue = `${before}${emoji} ${after}`;
-            const nextCursor = before.length + emoji.length + 1;
+
+            const nextChar = after.charAt(0);
+            const shouldAppendSpace = !nextChar || /[A-Za-z0-9]/.test(nextChar);
+            const separator = shouldAppendSpace ? ' ' : '';
+
+            const nextValue = `${before}${emoji}${separator}${after}`;
+            const nextCursor = before.length + emoji.length + separator.length;
 
             messageInput.value = nextValue;
             messageInput.selectionStart = messageInput.selectionEnd = nextCursor;


### PR DESCRIPTION
## Summary
This fixes shortcode emoji insertion so selecting a suggestion no longer always injects an extra trailing space. The composer now only appends a space when the next character is alphanumeric (or when inserting at end of input), preserving punctuation and existing spacing around the cursor.

## Changes
- Updated `applyShortcodeSelection` in `public/index.html`
- Added conditional spacing logic based on the character after the cursor
- Updated caret position calculation to match whether a separator was inserted

Fixes #173