### PR TITLE
feat: parse gateway reaction events and update UI in real-time (#175)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2373,6 +2373,10 @@
                 });
 
                 contentWrap.appendChild(row);
+
+                // Register this row for live updates when gateway reaction events arrive
+                if (!reactionRowsByKey.has(key)) reactionRowsByKey.set(key, new Set());
+                reactionRowsByKey.get(key).add(row);
             }
 
             // Add timestamp if provided

--- a/server.js
+++ b/server.js
@@ -1162,18 +1162,28 @@ app.get('/api/sessions/:sessionKey/history', isAuthenticated, async (req, res) =
           content = m.content?.text || m.text || JSON.stringify(m.content || '');
         }
 
+        const messageId =
+          m.messageId ||
+          m.message_id ||
+          m.id ||
+          m.externalMessageId ||
+          m.external_id ||
+          null;
+
         const text = role === 'assistant' ? sanitizeAssistantText(content) : content;
         const hasContent = typeof text === 'string' && text.trim().length > 0;
         const hasToolCalls = toolCalls.length > 0;
         if (!hasContent && !hasToolCalls) return null;
 
-        // Get reaction counts for this message (match by timestamp prefix)
+        // Get reaction counts for this message (match by timestamp prefix or gateway message id)
         const timestamp = m.timestamp;
         const messageReactions = [];
-        if (timestamp && sessionReactions) {
-          // Look for reactions with timestamp prefix (format: history:timestamp:role:...)
+        if (sessionReactions) {
           for (const [msgId, emojis] of Object.entries(sessionReactions)) {
-            if (msgId.startsWith(`history:${timestamp}:`) || msgId.startsWith(`reply:${timestamp}:`) || msgId.startsWith(`queued:${timestamp}`)) {
+            const matchesTimestamp = timestamp
+              && (msgId.startsWith(`history:${timestamp}:`) || msgId.startsWith(`reply:${timestamp}:`) || msgId.startsWith(`queued:${timestamp}`));
+            const matchesGatewayId = messageId && msgId === `gateway:${messageId}`;
+            if (matchesTimestamp || matchesGatewayId) {
               for (const [emoji, users] of Object.entries(emojis)) {
                 messageReactions.push({ emoji, count: users.length });
               }
@@ -1185,6 +1195,7 @@ app.get('/api/sessions/:sessionKey/history', isAuthenticated, async (req, res) =
           role,
           content: hasContent ? text : (hasToolCalls ? ' ' : ''),
           timestamp: m.timestamp,
+          ...(messageId ? { messageId: String(messageId) } : {}),
           ...(hasToolCalls ? { toolCalls } : {}),
           ...(messageReactions.length > 0 ? { reactions: messageReactions } : {}),
         };


### PR DESCRIPTION
## Summary
Implements frontend handling of OpenClaw gateway reaction events. When users react to messages on external channels (Discord, Telegram, Slack, Signal), these events are now parsed from system messages and the reaction UI updates in real-time without page refresh.

## Changes
- Extract messageId from gateway history for stable reaction identity
- Add parsers for Telegram, Slack, Discord, and Signal reaction event formats
- Register reaction rows for live sync when gateway events arrive via SSE
- Convert shortcode emojis (:thumbsup:) to Unicode for consistent display
- Match reactions by gateway message id to survive history re-renders

Fixes #175