### PR TITLE
fix(cors): add capacitor://localhost to default allowed origins

### DIFF
--- a/server.js
+++ b/server.js
@@ -46,7 +46,10 @@ const defaultCorsOrigins = [
   'ionic://localhost',
 ];
 
-const allowedCorsOrigins = new Set(configuredCorsOrigins.length > 0 ? configuredCorsOrigins : defaultCorsOrigins);
+const allowedCorsOrigins = new Set([
+  ...defaultCorsOrigins,
+  ...configuredCorsOrigins,
+]);
 
 // Enable CORS for frontend connection
 const corsOptions = {


### PR DESCRIPTION
Fixes mobile app CORS errors by adding capacitor://localhost to default allowed origins