### PR TITLE
fix: enable APK deep-link return for mobile OIDC

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="misochat" android:host="auth" android:pathPrefix="/callback" />
+            </intent-filter>
+
         </activity>
 
         <provider

--- a/public/index.html
+++ b/public/index.html
@@ -1737,7 +1737,7 @@
         function loginReturnToUrl() {
             const backend = getApiBaseUrl();
             if (isLikelyMobile()) {
-                const appReturn = new URL('capacitor://localhost/auth/callback');
+                const appReturn = new URL('misochat://auth/callback');
                 if (backend) {
                     appReturn.searchParams.set('backend', backend);
                 }

--- a/server.js
+++ b/server.js
@@ -235,7 +235,7 @@ if (oidcEnabled) {
   ));
 }
 
-const allowedReturnToSchemes = new Set(['http:', 'https:', 'capacitor:', 'ionic:']);
+const allowedReturnToSchemes = new Set(['http:', 'https:', 'capacitor:', 'ionic:', 'misochat:']);
 
 function getReturnTo(req, fallback = '/') {
   const raw = typeof req.body?.return_to === 'string' && req.body.return_to.trim()


### PR DESCRIPTION
## Summary
Follow-up to #225: enable Android to actually open the APK when OIDC flow returns.

## Changes
- Switch mobile return target to `misochat://auth/callback`
- Allow `misochat:` in return_to scheme allowlist
- Add Android `intent-filter` for `misochat://auth/callback`

## Why
Without an Android deep-link intent filter, browser auth completes in web context and cannot return into app.

Fixes #224