### PR TITLE
fix(apk-auth): add Capacitor App/Browser plugins for deterministic auth return

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.3.1",
       "dependencies": {
         "@capacitor/android": "^8.1.0",
+        "@capacitor/app": "^8.0.1",
+        "@capacitor/browser": "^8.0.1",
         "@capacitor/cli": "^8.1.0",
         "@capacitor/core": "^8.1.0",
         "better-sqlite3": "^12.0.0",
@@ -35,6 +37,24 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.1.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.0.1.tgz",
+      "integrity": "sha512-yeG3yyA0ETKqvgqexwHMBlmVOF13A1hRXzv/km0Ptv5TrNIZvZJK4MTI3uiqvnbHrzoJGP5DwWAjEXEfi90v3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/browser": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.1.tgz",
+      "integrity": "sha512-cCEYK9DGJvamfCKOh95QP+VafApblySDR/eodOcl1Qt+d/Y+NNPzc8NYm/dztQlRf3aMLJ7ne1HrRCfu2UOMnw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/cli": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "dependencies": {
     "@capacitor/android": "^8.1.0",
+    "@capacitor/app": "^8.0.1",
+    "@capacitor/browser": "^8.0.1",
     "@capacitor/cli": "^8.1.0",
     "@capacitor/core": "^8.1.0",
     "better-sqlite3": "^12.0.0",

--- a/public/index.html
+++ b/public/index.html
@@ -3447,33 +3447,38 @@
             await ensureMobileBackendConfigured();
 
             // Handle deep links on mobile (when app is opened via misochat:// URL)
-            if (isNativeCapacitor() && typeof window.Capacitor.addListener === 'function') {
-                window.Capacitor.addListener('appUrlOpen', async (data) => {
-                    try {
-                        const url = new URL(data.url);
-                        if (!(url.pathname === '/auth/callback' || url.pathname.endsWith('/auth/callback'))) return;
+            if (isNativeCapacitor()) {
+                const appPlugin = window.Capacitor?.Plugins?.App;
+                if (appPlugin && typeof appPlugin.addListener === 'function') {
+                    appPlugin.addListener('appUrlOpen', async (data) => {
+                        try {
+                            const url = new URL(data.url);
+                            if (!(url.pathname === '/auth/callback' || url.pathname.endsWith('/auth/callback'))) return;
 
-                        const backend = url.searchParams.get('backend');
-                        if (backend) setApiBaseUrl(backend);
+                            const backend = url.searchParams.get('backend');
+                            if (backend) setApiBaseUrl(backend);
 
-                        const token = url.searchParams.get('mobile_token');
-                        if (!token) {
-                            console.warn('[DeepLink] auth callback missing mobile_token');
-                            return;
+                            const token = url.searchParams.get('mobile_token');
+                            if (!token) {
+                                console.warn('[DeepLink] auth callback missing mobile_token');
+                                return;
+                            }
+
+                            await consumeMobileAuthToken(token);
+
+                            const browser = window.Capacitor?.Plugins?.Browser;
+                            if (browser && typeof browser.close === 'function') {
+                                try { await browser.close(); } catch {}
+                            }
+
+                            window.location.reload();
+                        } catch (error) {
+                            console.error('[DeepLink] callback handling failed', error);
                         }
-
-                        await consumeMobileAuthToken(token);
-
-                        const browser = window.Capacitor?.Plugins?.Browser;
-                        if (browser && typeof browser.close === 'function') {
-                            try { await browser.close(); } catch {}
-                        }
-
-                        window.location.reload();
-                    } catch (error) {
-                        console.error('[DeepLink] callback handling failed', error);
-                    }
-                });
+                    });
+                } else {
+                    console.warn('[DeepLink] App plugin unavailable');
+                }
             }
 
             await consumeMobileAuthTokenFromUrl();


### PR DESCRIPTION
## Summary
Ensure native OIDC flow actually uses Capacitor plugins at runtime.

## Root cause
APK had no Capacitor plugins registered (`capacitor.plugins.json` empty), so browser launch/callback handling was unreliable and could fall back to external browser context.

## Changes
- Add dependencies:
  - `@capacitor/app@8.0.1`
  - `@capacitor/browser@8.0.1`
- Use `window.Capacitor.Plugins.App.addListener('appUrlOpen', ...)` for callback handling
- Keep `Browser.close()` after successful token consume

## Notes
After merge, build a fresh APK from main so plugin sync includes App/Browser plugins.

Fixes #240
