### PR TITLE
fix(apk-auth): handle misochat://auth/callback deep-link parsing correctly

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3453,7 +3453,11 @@
                     appPlugin.addListener('appUrlOpen', async (data) => {
                         try {
                             const url = new URL(data.url);
-                            if (!(url.pathname === '/auth/callback' || url.pathname.endsWith('/auth/callback'))) return;
+                            const isExpectedCallback =
+                                (url.host === 'auth' && url.pathname === '/callback')
+                                || url.pathname === '/auth/callback'
+                                || url.pathname.endsWith('/auth/callback');
+                            if (!isExpectedCallback) return;
 
                             const backend = url.searchParams.get('backend');
                             if (backend) setApiBaseUrl(backend);


### PR DESCRIPTION
## Root cause
For URL , JS URL parser returns:
- host: 
- pathname: 

Our listener only accepted , so callback events were ignored.

## Fix
Accept callback when  in addition to existing path checks.

## Impact
Allows  token consume to run, close in-app browser, and restore app session.
