### PR TITLE
fix: remove obsolete quick-action styles (#37)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -622,39 +622,6 @@
             margin-bottom: 4px;
         }
         
-        /* Quick Actions */
-        .quick-actions {
-            display: flex;
-            gap: 8px;
-            padding: 0 16px 12px;
-            overflow-x: auto;
-            -webkit-overflow-scrolling: touch;
-            scrollbar-width: none;
-        }
-        
-        .quick-actions::-webkit-scrollbar {
-            display: none;
-        }
-        
-        .quick-btn {
-            flex-shrink: 0;
-            padding: 10px 16px;
-            background: var(--bg-tertiary);
-            border: 1px solid var(--border);
-            border-radius: 20px;
-            color: var(--text-primary);
-            font-size: 14px;
-            font-weight: 500;
-            white-space: nowrap;
-            transition: all 0.2s;
-        }
-        
-        .quick-btn:active {
-            transform: scale(0.95);
-            background: var(--accent);
-            border-color: var(--accent);
-        }
-        
         /* Input */
         .input-area {
             background: var(--bg-secondary);


### PR DESCRIPTION
## Summary
This PR removes legacy quick-action button styles that are no longer used in the chat UI. The quick-action feature has already been phased out, so keeping these CSS rules adds dead code and maintenance noise.

## Changes
- Removed `.quick-actions` CSS block from `public/index.html`
- Removed `.quick-btn` and related active/scrollbar style rules
- Kept all active UI behavior unchanged

Fixes #37