### PR TITLE
fix: automate release readiness checks (#254)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,3 +132,30 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           docker buildx imagetools inspect ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}
+
+  release-readiness:
+    name: Release readiness checks
+    runs-on: ubuntu-latest
+    needs: merge
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify release tag, image, and deploy smoke
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DEPLOY_HEALTH_URL: ${{ secrets.RELEASE_SMOKE_HEALTH_URL }}
+        run: ./scripts/release-readiness-check.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,6 +34,10 @@ git push && git push --tags
 1. Create release from tag on GitHub
 2. Add release notes
 3. Image automatically tagged with version
+4. `release.yaml` runs automated readiness checks:
+   - semantic release tag validation
+   - GHCR image existence for the release tag
+   - optional deploy smoke check via `RELEASE_SMOKE_HEALTH_URL` secret
 
 ## Image Tags
 | Event | Tag |

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "node --check server.js",
     "test": "node --check server.js && node --test tests/security.test.js",
     "test:ci": "npm run test && echo '{}' > test-results.json",
+    "release:readiness": "./scripts/release-readiness-check.sh",
     "audit:deps": "npm audit --omit=dev --audit-level=high",
     "android:sync": "npx cap sync android",
     "android:build": "npx cap sync android && cd android && ./gradlew assembleDebug",

--- a/scripts/release-readiness-check.sh
+++ b/scripts/release-readiness-check.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+  echo "GITHUB_REPOSITORY is required (e.g. joryirving/miso-chat)"
+  exit 1
+fi
+
+if [[ -z "${RELEASE_TAG:-}" ]]; then
+  echo "RELEASE_TAG is required (e.g. v0.3.1)"
+  exit 1
+fi
+
+VERSION="${RELEASE_TAG#v}"
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Release tag must be semantic (got: ${RELEASE_TAG})"
+  exit 1
+fi
+
+echo "✅ Release tag is semantic: ${RELEASE_TAG}"
+
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-ghcr.io}"
+IMAGE_REF="${IMAGE_REGISTRY}/${GITHUB_REPOSITORY}:${VERSION}"
+
+echo "🔎 Checking image exists: ${IMAGE_REF}"
+docker buildx imagetools inspect "${IMAGE_REF}" >/dev/null
+
+echo "✅ Image exists for release tag"
+
+if [[ -z "${DEPLOY_HEALTH_URL:-}" ]]; then
+  echo "ℹ️ DEPLOY_HEALTH_URL not set; skipping deployed smoke verification"
+  exit 0
+fi
+
+echo "🔎 Checking deployed health endpoint: ${DEPLOY_HEALTH_URL}"
+HEALTH_PAYLOAD="$(curl -fsS --retry 3 --retry-delay 2 "${DEPLOY_HEALTH_URL}")"
+HEALTH_STATUS="$(jq -r '.status // empty' <<<"${HEALTH_PAYLOAD}")"
+
+if [[ "${HEALTH_STATUS}" != "healthy" ]]; then
+  echo "Deploy health check failed: expected status=healthy, got '${HEALTH_STATUS:-<empty>}'"
+  exit 1
+fi
+
+DEPLOYED_VERSION="$(jq -r '.version // empty' <<<"${HEALTH_PAYLOAD}")"
+if [[ -n "${DEPLOYED_VERSION}" && "${DEPLOYED_VERSION}" != "${VERSION}" ]]; then
+  echo "Deploy version mismatch: expected ${VERSION}, got ${DEPLOYED_VERSION}"
+  exit 1
+fi
+
+echo "✅ Deploy health check passed"
+if [[ -n "${DEPLOYED_VERSION}" ]]; then
+  echo "✅ Deploy version matches release: ${DEPLOYED_VERSION}"
+else
+  echo "ℹ️ Deploy health payload did not include version; status-only smoke passed"
+fi

--- a/server.js
+++ b/server.js
@@ -38,6 +38,22 @@ const MAX_CHAT_MESSAGE_LENGTH = (() => {
   const parsed = Number(process.env.MAX_CHAT_MESSAGE_LENGTH || 4000);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 4000;
 })();
+const APP_VERSION = (() => {
+  if (typeof process.env.APP_VERSION === 'string' && process.env.APP_VERSION.trim()) {
+    return process.env.APP_VERSION.trim();
+  }
+
+  try {
+    const pkg = require('./package.json');
+    if (typeof pkg?.version === 'string' && pkg.version.trim()) {
+      return pkg.version.trim();
+    }
+  } catch (error) {
+    console.warn('Unable to resolve app version from package.json:', error.message);
+  }
+
+  return 'unknown';
+})();
 
 // SSE clients for real-time gateway event forwarding
 const sseClients = new Set();
@@ -549,6 +565,7 @@ let gatewayWsLastClose = null;
 app.get('/api/health', (req, res) => {
   res.json({
     status: 'healthy',
+    version: APP_VERSION,
     uptime: process.uptime(),
     timestamp: new Date().toISOString(),
     gatewayWsConnected: gatewayWsManager?.isConnected?.() || false,


### PR DESCRIPTION
## Summary
This PR automates release-readiness validation so published releases are gated by concrete checks instead of manual verification. It validates semantic tag format, verifies the matching GHCR image exists, and optionally runs a deployed health smoke check. It also exposes app version in `/api/health` so deploy verification can assert the expected release version.

## Changes
- Added `scripts/release-readiness-check.sh` to validate release tag, image availability, and optional deploy health check
- Added a new `release-readiness` job to `.github/workflows/release.yaml` that runs after image manifest publish
- Added `release:readiness` npm script and updated `RELEASE.md` with the new release automation behavior
- Added `version` field to `/api/health` response (with `APP_VERSION` env override and package fallback)

Fixes #254
