### PR TITLE
fix: add mobile auth regression checks for OIDC callback (#252)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "lint": "node --check server.js",
-    "test": "node --check server.js && node --test tests/security.test.js",
+    "test": "node --check server.js && node --test tests/security.test.js tests/mobile-auth-regression.test.js",
     "test:ci": "npm run test && echo '{}' > test-results.json",
     "release:readiness": "./scripts/release-readiness-check.sh",
     "smoke:deploy": "./scripts/post-deploy-smoke.sh",

--- a/tests/mobile-auth-regression.test.js
+++ b/tests/mobile-auth-regression.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const loginHtmlPath = path.join(__dirname, '..', 'public', 'login.html');
+const indexHtmlPath = path.join(__dirname, '..', 'public', 'index.html');
+const androidManifestPath = path.join(__dirname, '..', 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
+
+function read(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+test('mobile OIDC start keeps deep-link handoff query intact', () => {
+  const loginHtml = read(loginHtmlPath);
+
+  assert.match(loginHtml, /const mobile = params\.get\('mobile'\) === '1';/);
+  assert.match(loginHtml, /oidcTarget\.searchParams\.set\('return_to', returnTo\);/);
+  assert.match(loginHtml, /if \(mobile\) oidcTarget\.searchParams\.set\('mobile', '1'\);/);
+});
+
+test('mobile callback flow still consumes temporary auth token and can recover', () => {
+  const indexHtml = read(indexHtmlPath);
+
+  assert.match(indexHtml, /apiUrl\('\/api\/mobile-auth\/consume'\)/);
+  assert.match(indexHtml, /mobile_token/);
+  assert.match(indexHtml, /recoverFromMobileAuthCallbackFailure/);
+});
+
+test('android manifest keeps misochat deep-link callback intent filter', () => {
+  const manifest = read(androidManifestPath);
+
+  assert.match(manifest, /android:scheme="misochat"/);
+  assert.match(manifest, /android:host="auth"/);
+  assert.match(manifest, /android:pathPrefix="\/callback"/);
+});


### PR DESCRIPTION
## Summary
Adds regression coverage for the mobile OIDC login + deep-link callback path so callback contract regressions are caught before release. The checks verify the mobile handoff query is preserved at OIDC start, callback token-consume wiring remains present, and Android deep-link intent filters stay configured.

## Changes
- add `tests/mobile-auth-regression.test.js` to assert key mobile auth flow invariants
- run the new regression test in `npm test` so CI enforces it

Fixes #252
