### PR TITLE
fix: normalize Slack reaction shortcode parsing (#96)

### DIFF
--- a/lib/emoji-shortcodes.js
+++ b/lib/emoji-shortcodes.js
@@ -44,6 +44,8 @@ const EMOJI_SHORTCODES = Object.freeze({
   eyes: '👀',
   hundred: '💯',
   check: '✅',
+  white_check_mark: '✅',
+  heavy_check_mark: '✔️',
   x: '❌',
   warning: '⚠️',
   tada: '🎉',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "lint": "node --check server.js",
-    "test": "node --check server.js && node --test tests/security.test.js tests/mobile-auth-regression.test.js",
+    "test": "node --check server.js && node --test tests/security.test.js tests/mobile-auth-regression.test.js tests/reaction-events.test.js",
     "test:ci": "npm run test && echo '{}' > test-results.json",
     "release:readiness": "./scripts/release-readiness-check.sh",
     "smoke:deploy": "./scripts/post-deploy-smoke.sh",

--- a/tests/reaction-events.test.js
+++ b/tests/reaction-events.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseGatewayReactionEvent } = require('../lib/reaction-events');
+
+test('parses Slack :white_check_mark: reaction events into unicode emoji', () => {
+  const event = parseGatewayReactionEvent(
+    'Slack reaction added: :white_check_mark: by alice in #general msg 1732906502.139329 from bob'
+  );
+
+  assert.deepEqual(event, {
+    channel: 'slack',
+    action: 'added',
+    emoji: '✅',
+    actor: 'alice',
+    messageId: '1732906502.139329',
+    raw: 'Slack reaction added: :white_check_mark: by alice in #general msg 1732906502.139329 from bob',
+  });
+});
+
+test('keeps unknown shortcodes untouched for diagnostics', () => {
+  const event = parseGatewayReactionEvent(
+    'Slack reaction added: :custom_team_emoji: by miso in #chat msg 12345'
+  );
+
+  assert.equal(event.emoji, ':custom_team_emoji:');
+});


### PR DESCRIPTION
## Summary
This PR improves reaction-event normalization for Slack system events so commonly used checkmark shortcodes render as real emoji instead of raw `:shortcode:` text. It specifically handles `:white_check_mark:` while preserving unknown custom emoji shortcodes for diagnostics.

## Changes
- Added `white_check_mark` and `heavy_check_mark` aliases to the emoji shortcode map
- Added focused unit tests for Slack reaction parsing and unknown shortcode fallback
- Included the new reaction-events test file in the default `npm test` command

Fixes #96
