### PR TITLE
fix: validate push notification prerequisites (#255)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,18 @@ GATEWAY_URL=ws://openclaw.llm:18789
 # If your OpenClaw gateway requires auth, set this
 # GATEWAY_AUTH_TOKEN=your-gateway-token
 
+# -------------------- Push Notifications --------------------
+
+# Enable browser push notifications support
+# When enabled, all PUSH_VAPID_* vars below are required
+# PUSH_NOTIFICATIONS_ENABLED=false
+
+# Web Push VAPID keys + contact subject (required when enabled)
+# Generate with: npx web-push generate-vapid-keys
+# PUSH_VAPID_PUBLIC_KEY=your-vapid-public-key
+# PUSH_VAPID_PRIVATE_KEY=your-vapid-private-key
+# PUSH_VAPID_SUBJECT=mailto:admin@example.com
+
 # -------------------- Authentication --------------------
 
 # Session secret (REQUIRED - use a strong random string)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ docker run -d --name miso-chat \
 | `LOCAL_USERS` | If local | `admin:password123` | Users (user:pass) |
 | `REDIS_URL` | No | - | Optional Redis/Dragonfly session store |
 | `CAPACITOR_COOKIES_ENABLED` | No | `true` | Enable Capacitor cookie bridge for native app builds |
+| `PUSH_NOTIFICATIONS_ENABLED` | No | `false` | Enable browser push notification configuration |
+| `PUSH_VAPID_PUBLIC_KEY` | If push enabled | - | Public VAPID key exposed to clients |
+| `PUSH_VAPID_PRIVATE_KEY` | If push enabled | - | Private VAPID key used server-side |
+| `PUSH_VAPID_SUBJECT` | If push enabled | - | Contact URI for VAPID claims (for example `mailto:admin@example.com`) |
+
+Generate VAPID keys with:
+
+```bash
+npx web-push generate-vapid-keys
+```
+
+When `PUSH_NOTIFICATIONS_ENABLED=true`, startup now fails fast if any required `PUSH_VAPID_*` variable is missing.
 
 ## Security
 

--- a/server.js
+++ b/server.js
@@ -660,6 +660,15 @@ function inferAgentNameFromKey(sessionKey) {
 const CHAT_DISPLAY_NAME = process.env.CHAT_DISPLAY_NAME || process.env.ASSISTANT_NAME || 'Miso';
 const APP_TITLE = process.env.APP_TITLE || `${CHAT_DISPLAY_NAME} Chat`;
 const DEFAULT_SESSION_KEY = process.env.OPENCLAW_SESSION_KEY || process.env.MISO_CHAT_SESSION_KEY || 'agent:main:main';
+const PUSH_NOTIFICATIONS_ENABLED = parseBooleanEnv(process.env.PUSH_NOTIFICATIONS_ENABLED, false);
+const PUSH_VAPID_PUBLIC_KEY = String(process.env.PUSH_VAPID_PUBLIC_KEY || '').trim();
+const PUSH_VAPID_PRIVATE_KEY = String(process.env.PUSH_VAPID_PRIVATE_KEY || '').trim();
+const PUSH_VAPID_SUBJECT = String(process.env.PUSH_VAPID_SUBJECT || '').trim();
+const PUSH_CONFIG_READY = Boolean(PUSH_VAPID_PUBLIC_KEY && PUSH_VAPID_PRIVATE_KEY && PUSH_VAPID_SUBJECT);
+
+if (PUSH_NOTIFICATIONS_ENABLED && !PUSH_CONFIG_READY) {
+  throw new Error('PUSH_NOTIFICATIONS_ENABLED=true requires PUSH_VAPID_PUBLIC_KEY, PUSH_VAPID_PRIVATE_KEY, and PUSH_VAPID_SUBJECT');
+}
 
 app.get('/api/config', (req, res) => {
   res.json({
@@ -671,6 +680,10 @@ app.get('/api/config', (req, res) => {
     localAuthEnabled,
     oidcEnabled,
     oidcLabel: getOidcLabel(),
+    pushNotifications: {
+      enabled: PUSH_NOTIFICATIONS_ENABLED,
+      vapidPublicKey: PUSH_NOTIFICATIONS_ENABLED ? PUSH_VAPID_PUBLIC_KEY : '',
+    },
   });
 });
 
@@ -1654,6 +1667,7 @@ server.listen(PORT, async () => {
    Gateway WS Client: ${GATEWAY_WS_CLIENT_ID} (${GATEWAY_WS_CLIENT_MODE})
    Gateway Device Identity: ${fs.existsSync(GATEWAY_DEVICE_IDENTITY_PATH) ? GATEWAY_DEVICE_IDENTITY_PATH : 'missing'}
    Default Session: ${DEFAULT_SESSION_KEY}
+   Push Notifications: ${PUSH_NOTIFICATIONS_ENABLED ? `enabled (${PUSH_CONFIG_READY ? 'configured' : 'misconfigured'})` : 'disabled'}
    Auth: ${process.env.OIDC_ENABLED === 'true' ? 'OIDC' : 'Local'}
    Node Env: ${process.env.NODE_ENV || 'development'}
    


### PR DESCRIPTION
## Summary
This PR adds the missing push-notification configuration prerequisites needed to start implementing issue #255. The server now validates VAPID settings when push notifications are enabled and exposes push config readiness info to the frontend config payload. It also documents the required environment variables and key-generation command.

## Changes
- Added `PUSH_NOTIFICATIONS_ENABLED` and `PUSH_VAPID_*` environment variable guidance to `.env.example`
- Added fail-fast server validation when push notifications are enabled but VAPID settings are incomplete
- Exposed `pushNotifications.enabled` and `pushNotifications.vapidPublicKey` from `/api/config`
- Updated README configuration docs with push notification prerequisites and VAPID key generation command

Fixes #255
