### PR TITLE
fix: disable renovate dependency dashboard noise (#29)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,4 +1,5 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>joryirving/renovate-config"],
+  dependencyDashboard: false,
 }


### PR DESCRIPTION
## Summary
This PR disables Renovate's dependency dashboard issue for this repository.
The current dashboard issue (#29) is informational only and not actionable, so turning it off reduces issue noise while keeping dependency updates active.

## Changes
- Added `dependencyDashboard: false` to `.renovaterc.json5`
- Kept the shared Renovate preset (`github>joryirving/renovate-config`) unchanged

Fixes #29
