### PR TITLE
fix: disable Renovate dependency dashboard issue (#29)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,4 +1,5 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>joryirving/renovate-config"],
+  dependencyDashboard: false,
 }


### PR DESCRIPTION
## Summary
This PR disables Renovate's dependency dashboard for this repository so the auto-generated dashboard issue does not remain open indefinitely.
This keeps the issue list focused on actionable project work.

## Changes
- Set `dependencyDashboard: false` in `.renovaterc.json5`

Fixes #29