### PR TITLE
fix: restore image embed functionality

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2926,7 +2926,17 @@
             }
         }
 
-        function addMessage(sender, content, options = {}) {
+        
+    function addImage(url) {
+        const div = document.createElement('div'); div.className = 'message miso';
+        const img = document.createElement('img'); img.src = url; img.loading = 'lazy';
+        img.style.maxWidth = '100%'; img.style.borderRadius = '8px'; img.style.marginTop = '8px';
+        img.onload = () => { messagesDiv.scrollTop = messagesDiv.scrollHeight; };
+        img.onerror = () => { div.innerHTML = '<a href="' + url + '" target="_blank" style="display:block;padding:12px;background:var(--bg-secondary);border-radius:8px;margin-top:8px;">View Image</a>'; div.querySelector('a').style.color = 'var(--accent)'; };
+        div.appendChild(img); messagesDiv.appendChild(div);
+    }
+
+    function addMessage(sender, content, options = {}) {
             const div = document.createElement('div');
             div.className = `message ${sender}`;
 
@@ -3331,6 +3341,11 @@
                     if ((text && text.trim()) || toolCalls.length > 0) {
                         if (text && text.trim()) rememberLocalAssistantEcho(text);
                         addMessage('miso', text || '', { reactionKeyHint: `reply:${next.id}`, toolCalls });
+                    // Handle images in response
+                    if (data.images && Array.isArray(data.images)) {
+                        data.images.forEach(img => addImage(img));
+                    }
+
                     }
 
                     // Remove typing indicator after getting response


### PR DESCRIPTION
Restores image embedding that was present in v0.1.0 but was lost during later refactoring.

- Adds addImage() function to display images in messages
- Adds CSS for link-preview styling  
- Adds image detection when processing assistant responses (data.images)