### PR TITLE
fix: add OG link preview cards (#285)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -432,6 +432,71 @@
             color: #93c5fd;
         }
 
+        .link-previews {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .link-preview-card {
+            display: flex;
+            gap: 10px;
+            padding: 10px;
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            text-decoration: none;
+            color: inherit;
+            background: rgba(255, 255, 255, 0.03);
+            transition: border-color 0.2s ease, background 0.2s ease;
+        }
+
+        .link-preview-card:hover {
+            border-color: rgba(125, 211, 252, 0.6);
+            background: rgba(125, 211, 252, 0.06);
+        }
+
+        .link-preview-image {
+            width: 72px;
+            height: 72px;
+            border-radius: 8px;
+            object-fit: cover;
+            flex-shrink: 0;
+            background: rgba(255, 255, 255, 0.08);
+        }
+
+        .link-preview-body {
+            min-width: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .link-preview-title {
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--text-primary);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .link-preview-description {
+            font-size: 12px;
+            color: var(--text-secondary);
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 2;
+            overflow: hidden;
+            word-break: break-word;
+        }
+
+        .link-preview-domain {
+            font-size: 11px;
+            color: #7dd3fc;
+            letter-spacing: 0.01em;
+        }
+
         .code-block {
             margin-top: 8px;
             border: 1px solid var(--border);
@@ -1144,6 +1209,9 @@
         const TABLE_REGEX = /\|[^\n]+\|\n\|[-:|\s]+\|\n((?:\|[^\n]+\|\n?)+)/g;
         const INLINE_CODE_REGEX = /`([^`\n]+)`/g;
         const URL_REGEX = /(https?:\/\/[^\s<>"{}|\\^`\[\]]+)/g;
+        const MAX_LINK_PREVIEWS_PER_MESSAGE = 3;
+        const linkPreviewCache = new Map();
+        const pendingLinkPreviewRequests = new Map();
 
         function escapeHtml(value) {
             return String(value || '')
@@ -1352,6 +1420,159 @@
             
             URL_REGEX.lastIndex = 0;
             INLINE_CODE_REGEX.lastIndex = 0;
+        }
+
+        function extractUniqueUrls(source, max = MAX_LINK_PREVIEWS_PER_MESSAGE) {
+            const found = new Set();
+            const text = String(source || '');
+            for (const match of text.matchAll(URL_REGEX)) {
+                const candidate = String(match?.[1] || '').trim();
+                if (!candidate) continue;
+                try {
+                    const parsed = new URL(candidate);
+                    parsed.hash = '';
+                    found.add(parsed.toString());
+                } catch {
+                    // ignore invalid urls
+                }
+                if (found.size >= max) break;
+            }
+            URL_REGEX.lastIndex = 0;
+            return Array.from(found);
+        }
+
+        function normalizePreviewPayload(payload, fallbackUrl) {
+            const safeUrl = (() => {
+                try {
+                    return new URL(payload?.url || fallbackUrl).toString();
+                } catch {
+                    return '';
+                }
+            })();
+
+            if (!safeUrl) return null;
+
+            let domain = String(payload?.domain || '').trim();
+            if (!domain) {
+                try {
+                    domain = new URL(safeUrl).hostname;
+                } catch {
+                    domain = '';
+                }
+            }
+
+            const image = String(payload?.image || '').trim();
+            const title = String(payload?.title || '').trim();
+            const description = String(payload?.description || '').trim();
+
+            if (!title && !description && !image) {
+                return null;
+            }
+
+            return {
+                url: safeUrl,
+                title: title || domain || safeUrl,
+                description,
+                image,
+                domain,
+            };
+        }
+
+        async function fetchLinkPreview(url) {
+            if (linkPreviewCache.has(url)) {
+                return linkPreviewCache.get(url);
+            }
+
+            if (pendingLinkPreviewRequests.has(url)) {
+                return pendingLinkPreviewRequests.get(url);
+            }
+
+            const request = (async () => {
+                try {
+                    const response = await apiFetch(`/api/link-preview?url=${encodeURIComponent(url)}`);
+                    if (!response.ok) {
+                        linkPreviewCache.set(url, null);
+                        return null;
+                    }
+                    const payload = await response.json().catch(() => null);
+                    const preview = normalizePreviewPayload(payload, url);
+                    linkPreviewCache.set(url, preview);
+                    return preview;
+                } catch (error) {
+                    console.warn('Link preview request failed:', error);
+                    linkPreviewCache.set(url, null);
+                    return null;
+                } finally {
+                    pendingLinkPreviewRequests.delete(url);
+                }
+            })();
+
+            pendingLinkPreviewRequests.set(url, request);
+            return request;
+        }
+
+        function buildLinkPreviewCard(preview) {
+            const card = document.createElement('a');
+            card.className = 'link-preview-card';
+            card.href = preview.url;
+            card.target = '_blank';
+            card.rel = 'noopener noreferrer';
+
+            if (preview.image) {
+                const image = document.createElement('img');
+                image.className = 'link-preview-image';
+                image.src = preview.image;
+                image.alt = '';
+                image.loading = 'lazy';
+                image.decoding = 'async';
+                image.referrerPolicy = 'no-referrer';
+                image.addEventListener('error', () => image.remove());
+                card.appendChild(image);
+            }
+
+            const body = document.createElement('div');
+            body.className = 'link-preview-body';
+
+            const titleEl = document.createElement('div');
+            titleEl.className = 'link-preview-title';
+            titleEl.textContent = preview.title;
+            body.appendChild(titleEl);
+
+            if (preview.description) {
+                const descEl = document.createElement('div');
+                descEl.className = 'link-preview-description';
+                descEl.textContent = preview.description;
+                body.appendChild(descEl);
+            }
+
+            if (preview.domain) {
+                const domainEl = document.createElement('div');
+                domainEl.className = 'link-preview-domain';
+                domainEl.textContent = preview.domain;
+                body.appendChild(domainEl);
+            }
+
+            card.appendChild(body);
+            return card;
+        }
+
+        async function appendLinkPreviews(container, text) {
+            const urls = extractUniqueUrls(text);
+            if (!urls.length) return;
+
+            const wrap = document.createElement('div');
+            wrap.className = 'link-previews';
+            container.appendChild(wrap);
+
+            for (const url of urls) {
+                const preview = await fetchLinkPreview(url);
+                if (!preview) continue;
+                wrap.appendChild(buildLinkPreviewCard(preview));
+            }
+
+            if (!wrap.childElementCount) {
+                wrap.remove();
+            }
         }
 
         function appendFencedCode(container, language, rawCode) {
@@ -2977,6 +3198,10 @@
                     copyCodeFromButton(btn);
                 });
                 contentWrap.appendChild(bubble);
+
+                if (hasText && sender !== 'system') {
+                    void appendLinkPreviews(contentWrap, text);
+                }
             }
 
             if (hasToolCalls) {

--- a/server.js
+++ b/server.js
@@ -56,6 +56,149 @@ const APP_VERSION = (() => {
   return 'unknown';
 })();
 
+const LINK_PREVIEW_TIMEOUT_MS = (() => {
+  const parsed = Number(process.env.LINK_PREVIEW_TIMEOUT_MS || 5000);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
+})();
+const LINK_PREVIEW_MAX_HTML_CHARS = (() => {
+  const parsed = Number(process.env.LINK_PREVIEW_MAX_HTML_CHARS || 250000);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 250000;
+})();
+const LINK_PREVIEW_USER_AGENT =
+  process.env.LINK_PREVIEW_USER_AGENT ||
+  `miso-chat-link-preview/${APP_VERSION} (+https://github.com/joryirving/miso-chat)`;
+
+function isPrivateIPv4(hostname) {
+  if (!/^\d+\.\d+\.\d+\.\d+$/.test(hostname)) return false;
+  const octets = hostname.split('.').map((part) => Number(part));
+  if (octets.length !== 4 || octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return false;
+  }
+
+  const [a, b] = octets;
+  return (
+    a === 10
+    || a === 127
+    || (a === 169 && b === 254)
+    || (a === 172 && b >= 16 && b <= 31)
+    || (a === 192 && b === 168)
+  );
+}
+
+function isPrivateIPv6(hostname) {
+  const normalized = String(hostname || '').toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
+  return (
+    normalized === '::1'
+    || normalized === '0:0:0:0:0:0:0:1'
+    || normalized.startsWith('fe80:')
+    || normalized.startsWith('fc')
+    || normalized.startsWith('fd')
+  );
+}
+
+function isForbiddenLinkPreviewHost(hostname) {
+  const normalized = String(hostname || '').toLowerCase();
+  if (!normalized) return true;
+  if (normalized === 'localhost' || normalized.endsWith('.localhost') || normalized.endsWith('.local')) {
+    return true;
+  }
+  if (isPrivateIPv4(normalized) || isPrivateIPv6(normalized)) {
+    return true;
+  }
+  return false;
+}
+
+function decodeHtmlEntities(value) {
+  return String(value || '')
+    .replace(/&amp;/gi, '&')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&apos;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>');
+}
+
+function normalizePreviewText(value) {
+  return decodeHtmlEntities(value).replace(/\s+/g, ' ').trim();
+}
+
+function parseTagAttributes(tag) {
+  const attributes = {};
+  const attrRegex = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
+  let match;
+  while ((match = attrRegex.exec(tag)) !== null) {
+    const key = String(match[1] || '').toLowerCase();
+    const value = match[2] ?? match[3] ?? match[4] ?? '';
+    if (key && !(key in attributes)) {
+      attributes[key] = value;
+    }
+  }
+  return attributes;
+}
+
+function resolveRelativeUrl(candidate, baseUrl) {
+  if (!candidate) return '';
+  try {
+    return new URL(candidate, baseUrl).toString();
+  } catch {
+    return '';
+  }
+}
+
+function extractLinkPreviewData(html, pageUrl) {
+  const metaMap = new Map();
+  const metaRegex = /<meta\s+[^>]*>/gi;
+  let metaMatch;
+
+  while ((metaMatch = metaRegex.exec(html)) !== null) {
+    const attrs = parseTagAttributes(metaMatch[0]);
+    const key = String(attrs.property || attrs.name || '').toLowerCase().trim();
+    const rawContent = attrs.content;
+    if (!key || !rawContent || metaMap.has(key)) continue;
+    const normalized = normalizePreviewText(rawContent);
+    if (normalized) metaMap.set(key, normalized);
+  }
+
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const titleFromTag = titleMatch ? normalizePreviewText(titleMatch[1]) : '';
+
+  const canonicalUrl =
+    resolveRelativeUrl(metaMap.get('og:url') || '', pageUrl)
+    || pageUrl;
+
+  const imageUrl =
+    resolveRelativeUrl(metaMap.get('og:image') || '', canonicalUrl)
+    || resolveRelativeUrl(metaMap.get('twitter:image') || '', canonicalUrl)
+    || '';
+
+  const title =
+    metaMap.get('og:title')
+    || metaMap.get('twitter:title')
+    || titleFromTag;
+
+  const description =
+    metaMap.get('og:description')
+    || metaMap.get('twitter:description')
+    || metaMap.get('description')
+    || '';
+
+  let domain = '';
+  try {
+    domain = new URL(canonicalUrl).hostname;
+  } catch {
+    domain = '';
+  }
+
+  return {
+    url: canonicalUrl,
+    title,
+    description,
+    image: imageUrl,
+    domain,
+    twitterCard: metaMap.get('twitter:card') || '',
+  };
+}
+
 // SSE clients for real-time gateway event forwarding
 const sseClients = new Set();
 
@@ -603,6 +746,67 @@ app.get('/api/health', (req, res) => {
     gatewayWsLastError,
     gatewayWsLastClose,
   });
+});
+
+// GET /api/link-preview?url=https://example.com - Fetch OG metadata for inline link cards
+app.get('/api/link-preview', isAuthenticated, async (req, res) => {
+  const rawUrl = typeof req.query?.url === 'string' ? req.query.url.trim() : '';
+  if (!rawUrl) {
+    return res.status(400).json({ error: 'url query parameter is required' });
+  }
+
+  let targetUrl;
+  try {
+    targetUrl = new URL(rawUrl);
+  } catch {
+    return res.status(400).json({ error: 'Invalid URL' });
+  }
+
+  if (!['http:', 'https:'].includes(targetUrl.protocol)) {
+    return res.status(400).json({ error: 'Only http(s) URLs are supported' });
+  }
+
+  if (isForbiddenLinkPreviewHost(targetUrl.hostname)) {
+    return res.status(400).json({ error: 'Local/private hosts are not allowed for previews' });
+  }
+
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), LINK_PREVIEW_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(targetUrl.toString(), {
+      method: 'GET',
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: {
+        Accept: 'text/html,application/xhtml+xml',
+        'User-Agent': LINK_PREVIEW_USER_AGENT,
+      },
+    });
+
+    if (!response.ok) {
+      return res.status(502).json({ error: `Upstream request failed (${response.status})` });
+    }
+
+    const contentType = String(response.headers.get('content-type') || '').toLowerCase();
+    if (contentType && !contentType.includes('text/html') && !contentType.includes('application/xhtml+xml')) {
+      return res.status(422).json({ error: 'URL does not point to an HTML document' });
+    }
+
+    const html = (await response.text()).slice(0, LINK_PREVIEW_MAX_HTML_CHARS);
+    const finalUrl = response.url || targetUrl.toString();
+    const preview = extractLinkPreviewData(html, finalUrl);
+
+    return res.json(preview);
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      return res.status(504).json({ error: `Preview fetch timed out after ${LINK_PREVIEW_TIMEOUT_MS}ms` });
+    }
+    console.warn('Link preview fetch failed:', error.message || error);
+    return res.status(502).json({ error: 'Unable to fetch link preview' });
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
 });
 
 // GET /api/openclaw-status - Return native OpenClaw session status card/details


### PR DESCRIPTION
## Summary
This adds Discord-style link preview support for URLs in chat messages. The server now fetches Open Graph/Twitter metadata from shared links and the client renders rich preview cards inline beneath the message bubble.

## Changes
- Added authenticated `/api/link-preview` endpoint with URL validation, timeout handling, HTML parsing, and OG metadata extraction
- Added client-side URL extraction + preview fetch/cache flow for message text
- Added UI styles/components to render preview cards with title, description, image thumbnail, and source domain
- Added guards for non-HTML targets and local/private hosts

Fixes #285
