### PR TITLE
fix: disable Renovate dependency dashboard (#29)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,4 +1,5 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>joryirving/renovate-config"],
+  dependencyDashboard: false,
 }


### PR DESCRIPTION
## Summary
This PR disables Renovate's dependency dashboard issue for this repository to reduce maintenance noise. Since updates can still be handled through normal Renovate PRs, this keeps issue tracking focused on actionable work.

## Changes
- Added `dependencyDashboard: false` to `.renovaterc.json5`
- Kept existing shared Renovate preset configuration unchanged

Fixes #29
