### PR TITLE
Fix: Include all session kinds in sessions list

### DIFF
--- a/server.js
+++ b/server.js
@@ -1659,6 +1659,7 @@ app.get('/api/sessions', isAuthenticated, async (req, res) => {
       limit: 200,
       includeLastMessage: true,
       includeDerivedTitles: true,
+      kind: "", // Empty string means all kinds (session, subagent, acp, etc.)
     };
 
     const wsSessionsList = async () => {


### PR DESCRIPTION
## Description

This PR fixes the session picker to show all agent sessions, not just the main/default session.

## Changes

- Added kind: '' parameter to gateway sessions_list call in /api/sessions endpoint
- This ensures subagent and ACP sessions are included in the session picker

## Fixes

- Fixes #330