### PR TITLE
fix: resolve 0.4.1 'Connecting...' frontend regression

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3792,6 +3792,8 @@
                     if ((text && text.trim()) || toolCalls.length > 0) {
                         if (text && text.trim()) rememberLocalAssistantEcho(text);
                         addMessage('miso', text || '', { reactionKeyHint: `reply:${next.id}`, toolCalls, model });
+                    }
+
                     // Handle images in response
                     if (data.images && Array.isArray(data.images)) {
                         data.images.forEach(img => addImage(img));
@@ -3800,13 +3802,6 @@
 
                 // Remove typing indicator after getting response
                 await pollSessionHistory();
-            } catch (error) {
-                sendFailed = true;
-                console.error('Send error:', error);
-                addMessage('system', `Send failed: ${error.message}`);
-                sendQueue.unshift(next);
-                savePendingQueue(sendQueue);
-            }
             } catch (error) {
                 sendFailed = true;
                 console.error('Send error:', error);


### PR DESCRIPTION
## Summary
Fixes the `0.4.1` frontend regression where the UI stays stuck on **"Connecting..."**.

Root cause was malformed control flow in `processQueue()` (`public/index.html`):
- missing closing brace for `if ((text && text.trim()) || toolCalls.length > 0)`
- duplicated `catch` block in the same `try/catch/finally` chain

This caused inline script parse/runtime failure and prevented app initialization.

## Changes
- properly close the `if` block before image handling
- remove duplicated `catch` block, leaving a single valid `try/catch/finally`

## Validation
- Extracted inline `<script>` and ran syntax validation with `node --check`
- Confirmed no `Unexpected token 'catch'` syntax error after patch

Closes #335
