### PR TITLE
Update package.json version to 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miso-chat",
-  "version": "0.3.1",
+  "version": "0.4.3",
   "private": true,
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
Fixes version display showing v0.3.1 instead of v0.4.3. The server reads version from package.json when APP_VERSION env var is not set.