### PR TITLE
chore: add auto-bump workflow for package.json

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,0 +1,49 @@
+---
+name: Auto-bump package.json version
+on:
+  push:
+    tags:
+      - 'v*'
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${{ github.ref_name }}"
+          # Remove 'v' prefix if present
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update package.json version
+        run: |
+          npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version
+
+      - name: Commit and push changes
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add package.json package-lock.json
+          git commit -m "chore: update package.json to ${{ steps.version.outputs.version }}"
+          git push origin HEAD:main
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5e91468a9c4192c315d31a92d2f71e915a303971 # v7.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/bump-version-${{ steps.version.outputs.version }}
+          title: 'chore: bump package.json to ${{ steps.version.outputs.version }}'
+          body: |
+            Auto-generated PR to update package.json version after tag ${{ github.ref_name }}
+          labels: chore


### PR DESCRIPTION
Automatically updates package.json version when a new tag is pushed. Uses npm version to update, commits to main, and creates a PR.