### PR TITLE
chore: fix bump-version workflow action version

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
           git push origin HEAD:main
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@5e91468a9c4192c315d31a92d2f71e915a303971 # v7.0.2
+        uses: peter-evans/create-pull-request@v7.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/bump-version-${{ steps.version.outputs.version }}


### PR DESCRIPTION
Update create-pull-request action to v7.0.3 (no SHA)