### PR TITLE
chore: fix bump-version workflow to create PR instead of pushing to main

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -30,14 +30,6 @@ jobs:
         run: |
           npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version
 
-      - name: Commit and push changes
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add package.json package-lock.json
-          git commit -m "chore: update package.json to ${{ steps.version.outputs.version }}"
-          git push origin HEAD:main
-
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7.0.3
         with:


### PR DESCRIPTION
Remove direct push to main, workflow now only creates PR