### PR TITLE
fix: handle mobile auth callback on cold app launch

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2566,6 +2566,11 @@
         }
 
         async function handleMobileAuthCallback(urlString, { reloadOnSuccess = false } = {}) {
+            if (!urlString || typeof urlString !== 'string') {
+                mobileAuthDebug('appUrlOpen callback invalid', String(urlString || ''));
+                return false;
+            }
+
             const url = new URL(urlString);
             mobileAuthDebug('appUrlOpen callback', urlString);
             if (!isExpectedMobileAuthCallback(url)) {
@@ -2602,6 +2607,30 @@
                 mobileAuthDebug('callback consume failed', error?.message || String(error));
                 await recoverFromMobileAuthCallbackFailure('auth callback token consume failed', error);
                 return true;
+            }
+        }
+
+
+        async function consumeMobileAuthTokenFromLaunchUrl() {
+            if (!isNativeCapacitor()) return false;
+
+            const appPlugin = window.Capacitor?.Plugins?.App;
+            if (!appPlugin || typeof appPlugin.getLaunchUrl !== 'function') {
+                mobileAuthDebug('launch url unavailable', 'App.getLaunchUrl missing');
+                return false;
+            }
+
+            try {
+                const launch = await appPlugin.getLaunchUrl();
+                const launchUrl = launch?.url || '';
+                mobileAuthDebug('launch url', launchUrl || '(none)');
+                if (!launchUrl) return false;
+
+                return await handleMobileAuthCallback(launchUrl, { reloadOnSuccess: false });
+            } catch (error) {
+                mobileAuthDebug('launch url check failed', error?.message || String(error));
+                console.error('[DeepLink] getLaunchUrl failed', error);
+                return false;
             }
         }
 
@@ -4413,7 +4442,10 @@ menuDesktopNotifyBtn?.addEventListener('click', async () => {            closeAc
                 }
             }
 
-            await consumeMobileAuthTokenFromUrl();
+            const consumedFromLaunchUrl = await consumeMobileAuthTokenFromLaunchUrl();
+            if (!consumedFromLaunchUrl) {
+                await consumeMobileAuthTokenFromUrl();
+            }
             await hydrateStoredSessionKey();
             await loadConfig();
             await loadSessions();


### PR DESCRIPTION
## Why
Mobile auth can return to a cold-started Capacitor app where `appUrlOpen` may not fire.
In that case the callback token never gets consumed and users stay in a 401 loop.

## What
- Add `consumeMobileAuthTokenFromLaunchUrl()` using `App.getLaunchUrl()`
- Process launch callback URL before the existing `window.location` token check
- Guard `handleMobileAuthCallback` against invalid/missing URL strings

## Result
Mobile auth token is consumed for both warm-start (`appUrlOpen`) and cold-start launch callbacks.
