### PR TITLE
fix(chat): prevent duplicate pending messages on reconnect (fixes #365)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3915,6 +3915,10 @@
         }
 
         function renderPendingForSession(sessionKey) {
+            // Clear existing pending message elements to prevent duplicates on reconnect
+            const pendingMessages = messagesDiv.querySelectorAll('.message[data-reaction-key-hint^="queued:"], .message[data-reaction-key-hint^="queued:"]');
+            pendingMessages.forEach((msg) => msg.remove());
+            
             const pending = sendQueue.filter((item) => !item.sessionKey || item.sessionKey === sessionKey);
             pending.forEach((item) => {
                 addMessage('user', item.message, {


### PR DESCRIPTION
## Summary

Prevent duplicate pending messages appearing after reconnect by clearing existing pending message elements before re-rendering.

## Problem

When `pollSessionHistory` detects a `likelyReset` (e.g., upstream history was cleared), it calls `renderHistory(messages)` followed by `renderPendingForSession(sessionKey)`. If `renderPendingForSession` was also called previously (e.g., before `startHistoryPolling`), the old pending messages would remain in the DOM while new ones were added, causing duplicates.

## Solution

Clear any existing pending message elements at the start of `renderPendingForSession` before adding new ones. This handles:
- Multiple `renderPendingForSession` calls during reconnect
- Session changes during polling
- Race conditions between `pollSessionHistory` and `selectSession`

## Acceptance Criteria

- [x] Pending messages are not duplicated after reconnect
- [x] Session state is properly cleared when switching sessions
- [x] No console errors during normal reconnect flow

Fixes #365
