### PR TITLE
fix(rate-limit): use express-rate-limit ipKeyGenerator for IPv6-safe key generation

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const http = require('http');
 const WebSocket = require('ws');
 const passport = require('passport');
 const LocalStrategy = require('passport-local').Strategy;
-const rateLimit = require('express-rate-limit');
+const { rateLimit, ipKeyGenerator } = require('express-rate-limit');
 const cors = require('cors');
 const https = require('https');
 const fs = require('fs');
@@ -315,14 +315,16 @@ const limiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: (req) => {
     const cfIp = req.headers['cf-connecting-ip'];
-    if (typeof cfIp === 'string' && cfIp.trim()) return cfIp.trim();
+    if (typeof cfIp === 'string' && cfIp.trim()) {
+      return ipKeyGenerator(cfIp.trim());
+    }
 
     const forwarded = req.headers['x-forwarded-for'];
     if (typeof forwarded === 'string' && forwarded.trim()) {
-      return forwarded.split(',')[0].trim();
+      return ipKeyGenerator(forwarded.split(',')[0].trim());
     }
 
-    return req.ip;
+    return ipKeyGenerator(req.ip);
   },
   skip: (req) => {
     // Never rate-limit realtime/bootstrap reads; this can deadlock the UI.


### PR DESCRIPTION
## Summary Replace raw IP string trimming with express-rate-limit's ipKeyGenerator() helper for all rate-limit key sources. ## Why The current implementation returns raw IPv6 addresses which can cause inconsistent rate-limit keys and startup crashes. ipKeyGenerator() provides IPv4-mapped IPv6 normalization and subnet masking. ## Changes - Import ipKeyGenerator from express-rate-limit - Wrap all IP sources with ipKeyGenerator() ## Validation - npm run lint passes - All 14 unit tests pass