### PR TITLE
fix(chat): clarify connecting status text as OpenClaw gateway

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1162,7 +1162,7 @@
             <h1 id="assistantName">Assistant</h1>
             <div class="status">
                 <span class="status-dot" id="statusDot"></span>
-                <span id="statusText">Connecting...</span>
+                <span id="statusText">Connecting to OpenClaw gateway…</span>
             </div>
             <div class="version-info" id="versionInfo">v0.0.0</div>
         </div>
@@ -2450,7 +2450,7 @@
             sseConnected = false;
             sseTypingActive = false;
             updateTypingIndicator();
-            setOnlineState(false, 'Connecting...');
+            setOnlineState(false, 'Connecting to OpenClaw gateway…');
             await loadSessions();
             connectEventSource();
             await refreshBackendHealth();
@@ -4593,7 +4593,7 @@ menuDesktopNotifyBtn?.addEventListener('click', async () => {            closeAc
             assistantNameEl.textContent = configuredAssistantName;
             messageInput.placeholder = `Message ${configuredAssistantName}...`; 
             resizeMessageInput();
-            setOnlineState(false, 'Connecting...');
+            setOnlineState(false, 'Connecting to OpenClaw gateway…');
             await ensureMobileBackendConfigured();
 
             // Handle deep links on mobile (when app is opened via misochat:// URL)


### PR DESCRIPTION
## Summary
- Changed 'Connecting...' status text to 'Connecting to OpenClaw gateway…' in 3 places (initial HTML, reconnect flow, initialization)
- Clarifies what the app is connecting to, reducing ambiguity about miso-chat's role as an authenticated OpenClaw frontend

## Validation
- npm test passes (14/14)

Fixes #378