### PR TITLE
chore(chat): remove dead attachment affordance leftovers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -859,52 +859,6 @@
         .input-wrapper textarea::placeholder {
             color: var(--text-secondary);
         }
-
-        .composer-attachment-preview {
-            margin-bottom: 8px;
-            border: 1px solid var(--border);
-            border-radius: 12px;
-            background: var(--bg-tertiary);
-            padding: 8px;
-            display: flex;
-            align-items: center;
-            gap: 10px;
-        }
-
-        .composer-attachment-preview img {
-            width: 48px;
-            height: 48px;
-            object-fit: cover;
-            border-radius: 8px;
-            border: 1px solid var(--border);
-        }
-
-        .composer-attachment-meta {
-            min-width: 0;
-            flex: 1;
-            font-size: 12px;
-            color: var(--text-secondary);
-        }
-
-        .composer-attachment-name {
-            display: block;
-            color: var(--text-primary);
-            font-size: 13px;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-
-        .composer-attachment-remove {
-            border: 1px solid var(--border);
-            background: transparent;
-            color: var(--text-secondary);
-            border-radius: 8px;
-            padding: 6px 8px;
-            cursor: pointer;
-            font-size: 12px;
-        }
-
         .attachment-list {
             display: flex;
             flex-direction: column;
@@ -1402,7 +1356,6 @@
         const INLINE_CODE_REGEX = /`([^`\n]+)`/g;
         const URL_REGEX = /(https?:\/\/[^\s<>"{}|\\^`\[\]]+)/g;
         const MAX_LINK_PREVIEWS_PER_MESSAGE = 3;
-        const ATTACHMENT_LINE_PREFIX = '[attachment:';
         const linkPreviewCache = new Map();
         const pendingLinkPreviewRequests = new Map();
 

--- a/server.js
+++ b/server.js
@@ -11,8 +11,6 @@ const cors = require('cors');
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
-const crypto = require('crypto');
-const multer = require('multer');
 require('dotenv').config();
 
 const { GatewayWsManager } = require('./lib/gateway-ws');
@@ -68,64 +66,6 @@ const LINK_PREVIEW_MAX_HTML_CHARS = (() => {
 const LINK_PREVIEW_USER_AGENT =
   process.env.LINK_PREVIEW_USER_AGENT ||
   `miso-chat-link-preview/${APP_VERSION} (+https://github.com/joryirving/miso-chat)`;
-const MAX_ATTACHMENT_BYTES = (() => {
-  const parsed = Number(process.env.MAX_ATTACHMENT_BYTES || 5 * 1024 * 1024);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5 * 1024 * 1024;
-})();
-const ALLOWED_ATTACHMENT_TYPES = new Set([
-  'image/png',
-  'image/jpeg',
-  'image/gif',
-  'image/webp',
-]);
-const ATTACHMENTS_DIR = path.join(__dirname, 'public', 'uploads');
-fs.mkdirSync(ATTACHMENTS_DIR, { recursive: true });
-
-function sanitizeAttachmentName(name) {
-  return String(name || 'attachment')
-    .replace(/[^a-zA-Z0-9._-]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-    .slice(0, 120) || 'attachment';
-}
-
-function inferAttachmentExtension(originalName, mimeType) {
-  const ext = path.extname(String(originalName || '')).toLowerCase();
-  if (ext) return ext;
-
-  const fallbackByMime = {
-    'image/png': '.png',
-    'image/jpeg': '.jpg',
-    'image/gif': '.gif',
-    'image/webp': '.webp',
-  };
-  return fallbackByMime[mimeType] || '.bin';
-}
-
-const attachmentStorage = multer.diskStorage({
-  destination: (_req, _file, cb) => cb(null, ATTACHMENTS_DIR),
-  filename: (_req, file, cb) => {
-    const baseName = sanitizeAttachmentName(path.basename(file.originalname, path.extname(file.originalname)));
-    const extension = inferAttachmentExtension(file.originalname, file.mimetype);
-    const unique = `${Date.now()}-${crypto.randomBytes(6).toString('hex')}`;
-    cb(null, `${unique}-${baseName}${extension}`);
-  },
-});
-
-const uploadAttachment = multer({
-  storage: attachmentStorage,
-  limits: {
-    fileSize: MAX_ATTACHMENT_BYTES,
-    files: 1,
-  },
-  fileFilter: (_req, file, cb) => {
-    if (!ALLOWED_ATTACHMENT_TYPES.has(file.mimetype)) {
-      cb(new Error('Unsupported attachment type'));
-      return;
-    }
-    cb(null, true);
-  },
-});
-
 function isPrivateIPv4(hostname) {
   if (!/^\d+\.\d+\.\d+\.\d+$/.test(hostname)) return false;
   const octets = hostname.split('.').map((part) => Number(part));


### PR DESCRIPTION
## Summary\n- remove dead server-side attachment upload plumbing left behind after the composer attachment affordance was removed\n- remove orphaned composer attachment preview CSS and unused attachment line prefix constant\n- keep rendered attachment display styles intact\n\n## Why\nIssue #376 is effectively satisfied at the UX level, but there was still dead housekeeping code from the old misleading attachment affordance path. This trims the leftovers without changing active message rendering.\n\nCloses #376