### PR TITLE
fix(chat): restore assistant header and message rendering

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3725,7 +3725,7 @@
             await persistStoredSessionKey(sessionKey);
             sessionSelect.value = sessionKey;
             const selectedMeta = sessionMetaByKey.get(sessionKey);
-            const sessionAssistant = configuredAssistantName || 'Assistant';
+            const sessionAssistant = selectedMeta?.agentName || selectedMeta?.title || selectedMeta?.name || selectedMeta?.displayName || configuredAssistantName || 'Assistant';
             assistantNameEl.textContent = sessionAssistant;
             messageInput.placeholder = `Message ${sessionAssistant}...`;
             clearQueueRetryTimer(true);

--- a/server.js
+++ b/server.js
@@ -938,10 +938,12 @@ function normalizeSessionItems(...sources) {
 
       if (!sessionKey) return null;
 
+      const title = String(item?.title || item?.name || '').trim();
+      const agentName = String(item?.agentName || item?.agent?.name || '').trim();
       const displayName = String(
         item?.displayName
-        || item?.title
-        || item?.name
+        || agentName
+        || title
         || inferAgentNameFromKey(sessionKey)
         || sessionKey
       ).trim();
@@ -949,6 +951,8 @@ function normalizeSessionItems(...sources) {
       return {
         ...item,
         sessionKey,
+        title,
+        agentName,
         displayName,
         provider: item?.provider || 'openclaw',
       };


### PR DESCRIPTION
Follow-up fix after the new 0.4.6 release still showed broken chat rendering.\n\nThis includes:\n- keep top-left assistant name pinned to configured assistant name instead of session nickname\n- normalize history message content server-side so message text renders again\n- disable the fake local-only reaction buttons\n\nWhy a new PR: #394 is already merged, but this follow-up commit (2b43783) is still ahead of main and is not included in the currently deployed 0.4.6.