### PR TITLE
fix(ui): restore grouped session picker and agent naming

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3041,48 +3041,56 @@
         }
 
 
-        function humanizeAgentToken(value) {
-            return String(value || '')
-                .trim()
-                .replace(/^g-agent-/, '')
-                .replace(/^agent[-:]/, '')
-                .replace(/[-_]/g, ' ')
-                .replace(/\w/g, (c) => c.toUpperCase());
+
+        const agentDirectoryById = new Map();
+
+        async function loadAgentDirectory() {
+            try {
+                const response = await apiFetch('/api/agents');
+                if (!response.ok) return;
+                const data = await response.json();
+                await loadAgentDirectory();
+                const agents = Array.isArray(data?.agents) ? data.agents : [];
+                agentDirectoryById.clear();
+                agents.forEach((agent) => {
+                    const id = String(agent?.id || '').trim();
+                    if (!id) return;
+                    agentDirectoryById.set(id, agent?.identity?.name || agent?.name || id);
+                });
+            } catch (_) {}
         }
 
-        function inferAgentNameFromSessionKey(sessionKey) {
-            if (!sessionKey || typeof sessionKey !== 'string') return null;
-
-            if (sessionKey.startsWith('agent:')) {
-                const parts = sessionKey.split(':');
-                if (parts.length >= 2 && parts[1]) {
-                    return humanizeAgentToken(parts[1]);
-                }
+        function extractAgentIdFromSessionKey(sessionKey) {
+            const value = String(sessionKey || '').trim();
+            if (!value) return null;
+            if (value.startsWith('agent:')) {
+                const parts = value.split(':');
+                return parts[1] || null;
             }
-
-            const webchatMatch = sessionKey.match(/(?:^|:)g-agent-([a-z0-9_]+)(?:[-:]|$)/i);
-            if (webchatMatch?.[1]) {
-                return humanizeAgentToken(webchatMatch[1]);
-            }
-
-            return null;
+            const match = value.match(/(?:^|:)g-agent-([a-z0-9_]+)(?:[-:]|$)/i);
+            return match?.[1] || null;
         }
 
-        function getSessionAgentName(session) {
-            return session?.agentName
-                || session?.agent?.name
-                || inferAgentNameFromSessionKey(session?.sessionKey)
-                || null;
+        async function loadAssistantIdentity(sessionKey) {
+            const response = await apiFetch(`/api/assistant-identity?sessionKey=${encodeURIComponent(sessionKey)}`);
+            if (!response.ok) return null;
+            const data = await response.json();
+            return data?.assistantName ? data : null;
+        }
+
+        function getSessionAgentGroupLabel(session) {
+            const agentId = session?.assistantAgentId || session?.agentId || extractAgentIdFromSessionKey(session?.sessionKey);
+            if (!agentId) return null;
+            return agentDirectoryById.get(agentId) || agentId;
         }
 
         function getSessionOptionLabel(session) {
             const key = session?.sessionKey || '';
             const shortKey = key.slice(0, 8);
-            const agentName = getSessionAgentName(session);
-            const candidates = [session?.title, session?.name, session?.displayName]
+            const candidates = [session?.title, session?.name, session?.displayName, session?.label]
                 .map((value) => String(value || '').trim())
                 .filter(Boolean)
-                .filter((value) => value !== agentName && value !== key);
+                .filter((value) => value !== key);
             return candidates[0] || shortKey || key || 'session';
         }
 
@@ -3138,9 +3146,7 @@
         }
 
         function buildSessionLabel(session) {
-            const agentName = getSessionAgentName(session);
-            const optionLabel = getSessionOptionLabel(session);
-            return agentName ? `${optionLabel}` : optionLabel;
+            return getSessionOptionLabel(session);
         }
 
         function resolvePreferredSession(sessions) {
@@ -3731,7 +3737,7 @@
                 const groups = new Map();
                 sessions.forEach((session) => {
                     if (session?.sessionKey) sessionMetaByKey.set(session.sessionKey, session);
-                    const agentName = getSessionAgentName(session) || 'Other';
+                    const agentName = getSessionAgentGroupLabel(session) || 'Other';
                     if (!groups.has(agentName)) groups.set(agentName, []);
                     groups.get(agentName).push(session);
                 });
@@ -3795,7 +3801,8 @@
             await persistStoredSessionKey(sessionKey);
             sessionSelect.value = sessionKey;
             const selectedMeta = sessionMetaByKey.get(sessionKey);
-            const sessionAssistant = selectedMeta?.agentName || getSessionAgentName(selectedMeta) || configuredAssistantName || 'Assistant';
+            const identity = await loadAssistantIdentity(sessionKey).catch(() => null);
+            const sessionAssistant = identity?.assistantName || configuredAssistantName || 'Assistant';
             assistantNameEl.textContent = sessionAssistant;
             messageInput.placeholder = `Message ${sessionAssistant}...`;
             clearQueueRetryTimer(true);

--- a/server.js
+++ b/server.js
@@ -962,6 +962,36 @@ function normalizeSessionItems(...sources) {
     .filter((item, index, arr) => arr.findIndex((other) => other.sessionKey === item.sessionKey) === index);
 }
 
+
+app.get('/api/assistant-identity', isAuthenticated, async (req, res) => {
+  try {
+    const sessionKey = String(req.query.sessionKey || '').trim();
+    if (!sessionKey) return res.status(400).json({ error: 'sessionKey required' });
+    const result = await gatewayInvoke('agent_identity_get', { sessionKey });
+    const payload = unwrapToolResult(result);
+    return res.json({
+      assistantName: payload?.name || payload?.assistantName || payload?.identity?.name || null,
+      assistantAvatar: payload?.avatarUrl || payload?.assistantAvatar || payload?.identity?.avatarUrl || null,
+      assistantAgentId: payload?.agentId || payload?.assistantAgentId || payload?.id || null,
+    });
+  } catch (error) {
+    console.error('Error fetching assistant identity:', error.message);
+    return res.status(502).json({ error: error.message || 'Failed to fetch assistant identity' });
+  }
+});
+
+app.get('/api/agents', isAuthenticated, async (_req, res) => {
+  try {
+    const result = await gatewayInvoke('agents_list', {});
+    const payload = unwrapToolResult(result);
+    const agents = Array.isArray(payload?.agents) ? payload.agents : Array.isArray(payload) ? payload : [];
+    return res.json({ agents });
+  } catch (error) {
+    console.error('Error fetching agents list:', error.message);
+    return res.status(502).json({ error: error.message || 'Failed to fetch agents list' });
+  }
+});
+
 app.get('/api/sessions', isAuthenticated, async (req, res) => {
   try {
     if (await waitForGatewayWsReady()) {


### PR DESCRIPTION
Restores the next live follow-up items:
- agent-aware header naming from session metadata/session key
- grouped session picker by agent
- includes the already-tested live WS/session compatibility fix from aeffcbd so the bad includeArchived/sessions.history path is part of the same releaseable branch

Validation:
- node --check server.js
- node --check extracted public/index.html script
- node --test tests/security.test.js tests/mobile-auth-regression.test.js tests/reaction-events.test.js tests/regression-contracts.test.js