### PR TITLE
fix(chat): render direct image URLs as inline images (fixes #411)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1720,6 +1720,10 @@
             container.appendChild(wrap);
 
             for (const url of urls) {
+                if (isDirectImageUrl(url)) {
+                    addImage(url);
+                    continue;
+                }
                 const preview = await fetchLinkPreview(url);
                 if (!preview) continue;
                 wrap.appendChild(buildLinkPreviewCard(preview));
@@ -1727,6 +1731,16 @@
 
             if (!wrap.childElementCount) {
                 wrap.remove();
+            }
+        }
+
+        function isDirectImageUrl(url) {
+            try {
+                const parsed = new URL(url);
+                const pathname = parsed.pathname.toLowerCase();
+                return /\.(jpg|jpeg|png|gif|webp|bmp|svg)(\?|$)/.test(pathname);
+            } catch {
+                return false;
             }
         }
 


### PR DESCRIPTION
## Summary
Detect direct image URLs (jpg, jpeg, png, gif, webp, bmp, svg) in `appendLinkPreviews` and call `addImage(url)` instead of `fetchLinkPreview(url)`. Direct image URLs with no OG meta tags now render as inline images instead of producing empty preview cards.

## Classification
**FULL FIX** — This change satisfies all acceptance criteria for #411.

## What Changed
- Added `isDirectImageUrl(url)` helper that checks URL pathname against image extensions
- Modified `appendLinkPreviews` to intercept direct image URLs and call `addImage(url)` before attempting link preview fetch
- `addImage` already handles lazy loading (`loading="lazy"`) and error fallback ("View Image" link)

## Acceptance Criteria Met
- ✅ Pasting `https://example.com/photo.jpg` in chat renders the image inline
- ✅ Pasting `https://example.com/photo.png` in chat renders the image inline
- ✅ Pasting `https://example.com/photo.gif` in chat renders the image inline
- ✅ Non-image URLs still produce OG link preview cards as before
- ✅ Image embed respects lazy loading and has error fallback ("View Image" link)
- ✅ Existing link preview cards with `og:image` are not broken

## Tests
All 22 tests pass.

Fixes #411