### PR TITLE
fix(mobile): reload page after mobile auth callback to prevent 401 loop

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2599,14 +2599,15 @@
                 await closeNativeBrowserIfOpen();
 
                 if (reloadOnSuccess) {
+                    // Clean the URL of auth params BEFORE reload to prevent re-triggering
+                    // the consume flow on page load.
                     const current = new URL(window.location.href);
                     current.searchParams.delete('mobile_token');
                     current.searchParams.delete('backend');
                     window.history.replaceState({}, '', current.toString());
-                    await loadConfig().catch(() => {});
-                    await loadSessions().catch(() => {});
-                    connectEventSource();
-                    await refreshBackendHealth().catch(() => {});
+                    // Force a full page reload so the WebView re-initializes with the
+                    // session cookie set by the consume endpoint, preventing 401 loops.
+                    window.location.reload();
                 }
                 return true;
             } catch (error) {

--- a/server.js
+++ b/server.js
@@ -477,7 +477,7 @@ function requestWantsJson(req) {
 }
 
 const mobileAuthHandoffs = new Map();
-const MOBILE_AUTH_TTL_MS = Number(process.env.MOBILE_AUTH_TTL_MS || 2 * 60 * 1000);
+const MOBILE_AUTH_TTL_MS = Number(process.env.MOBILE_AUTH_TTL_MS || 30 * 60 * 1000);
 
 function issueMobileAuthToken(user) {
   const token = crypto.randomBytes(24).toString('hex');

--- a/server.js
+++ b/server.js
@@ -477,7 +477,7 @@ function requestWantsJson(req) {
 }
 
 const mobileAuthHandoffs = new Map();
-const MOBILE_AUTH_TTL_MS = Number(process.env.MOBILE_AUTH_TTL_MS || 30 * 60 * 1000);
+const MOBILE_AUTH_TTL_MS = Number(process.env.MOBILE_AUTH_TTL_MS || 2 * 60 * 1000);
 
 function issueMobileAuthToken(user) {
   const token = crypto.randomBytes(24).toString('hex');


### PR DESCRIPTION
## Summary

When the APK WebView handles a mobile auth callback (`misochat://auth?mobile_token=...&backend=...`), the previous code tried to perform an in-place state refresh (`loadConfig`, `loadSessions`, etc.) without a full page reload. This appeared to cause the session cookie set by the consume endpoint to not be properly picked up by the WebView, resulting in a 401 loop back to Authentik.

This change forces a full `window.location.reload()` after a successful auth consume. The URL is cleaned of auth params before reload to prevent re-triggering the consume flow on page load.

## Classification

**PARTIAL FIX** — This addresses the observed 401 auth loop by ensuring the WebView re-initializes with a clean, fully authenticated state after consuming the mobile auth token.

## Changes

- `public/index.html`: Modified `handleMobileAuthCallback` to call `window.location.reload()` instead of in-place state refresh after successful token consumption.

## Remaining work

- Verify the fix on an actual APK/mobile device to confirm the loop is broken.
- Verify that the `backend` parameter in the deep link is correctly preserved or handled during the reload.
- Ensure that standard web-based Authentik redirects are not negatively affected.
- Consider adding debug logging to the mobile auth flow to better diagnose future issues.

## References

Refs: #423