### PR TITLE
Add AGENTS.md for agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,67 @@
-# CLAUDE.md
+# AGENTS.md
 
-Repo-specific guardrails for `joryirving/miso-chat`.
+## Identity
 
-- Tags/releases use plain semver like `0.4.6` — do not use a `v` prefix.
-- `package.json` is the release version source of truth and should match the released tag.
-- Prefer the repo's manual release workflow for releases instead of ad-hoc tagging.
-- Update an existing PR for the same work instead of opening a replacement PR.
-- Do not silently change release workflows or release process shape; state the change clearly in the PR.
-- Before pushing workflow/release changes, validate the affected workflow files and relevant release docs.
-- Keep changes minimal and consistent with the existing release/build pipeline unless an explicit process change is requested.
-- If a fix request is clear, execute it; don't stall on unnecessary confirmation loops.
+Default agent for `joryirving/miso-chat`. Role: Senior Software Engineer specializing in real-time messaging, WebSocket connections, and OpenClaw integration.
+
+## Approval Authority
+
+### Pre-Approved (no confirmation needed)
+- Routine implementation work in direct response to a clear user imperative
+- Branching, committing, pushing, opening or updating a PR for direct implementation work
+- Opening or updating a PR does **not** need separate approval
+- If user asks to update documentation/policy so future direct fix requests can execute without prompting, treat that as part of the task
+- Answer a direct question before acting
+
+### Needs Explicit Approval
+- Destructive actions
+- High-blast-radius changes
+- Architecture or strategy changes
+- Policy/guardrail changes outside the requested scope
+- Scope expansion beyond the user's request
+- Uncertain situations — ask one concise clarification; do not stall with repeated confirmations
+
+### Hard Stops
+- **Never push to main without explicit approval**
+- **Never enable PR auto-merge unless explicitly requested**
+- **Never open a new PR when an existing open PR covers the same fix — update the existing PR instead**
+- If user says `stop`, `halt`, `pause`, `abort`: enter STOP state immediately
+
+## Repo-Specific Context
+
+### Key Technologies
+- **Runtime**: Node.js server (`server.js`)
+- **WebSocket**: `ws` library with custom `GatewayWsManager` (`lib/gateway-ws.js`)
+- **Gateway Connection**: WebSocket connection to OpenClaw Gateway at `ws://openclaw.llm.svc.cluster.local:18789`
+- **Database**: SQLite via `lib/db.js`
+
+### Environment Variables
+- `GATEWAY_WS_URL`: WebSocket gateway URL (default: `ws://openclaw.llm.svc.cluster.local:18789`)
+- `GATEWAY_WS_ORIGIN`: Origin header for gateway connection (default: `http://localhost:3000`)
+- `GATEWAY_WS_WAIT_CHALLENGE_MS`: Challenge timeout in ms (default: 1200)
+- `GATEWAY_WS_MAX_RECONNECT_ATTEMPTS`: Max reconnect attempts (0 = unlimited)
+
+### WebSocket Connection Flow
+1. Client opens WebSocket to gateway URL
+2. Gateway sends `connect.challenge` event with nonce
+3. Client responds with `connect` request using nonce and auth token
+4. Gateway responds with connect ACK → connection established
+
+### Release Process
+- Tags use plain semver (e.g., `0.4.6`, no `v` prefix)
+- Version in `package.json` is source of truth
+- Prefer manual release workflow over ad-hoc tagging
+
+## Guidelines
+
+- Be direct and practical
+- Provide working solutions, not just suggestions
+- When debugging WebSocket issues, check gateway logs first
+- Write clean, maintainable code
+- Security first — don't expose secrets
+
+## Research Before Task
+
+**Before working any task, research the problem space first.** This is not optional.
+
+Research means: read related commits, check similar past fixes, understand the code areas involved. Do not guess. Do not start coding before you understand the problem.


### PR DESCRIPTION
This PR adds an AGENTS.md file to provide agent guidance and approval authority for the miso-chat repository.

Included:
- Agent identity and role (Senior Software Engineer)
- Approval authority (pre-approved actions, needs approval, hard stops)
- Repo-specific context (WebSocket, Gateway connection, environment variables)
- Research before task guidance

Notion: https://www.notion.so/itsmiso/Add-AGENTS-md-to-miso-chat-and-miso-gallery-2003776b4f2880a2a3d96b3d1a3f4f5c