### PR TITLE
misospace/miso-chat #446: cap WebSocket reconnect backoff delay

### DIFF
--- a/lib/gateway-ws.js
+++ b/lib/gateway-ws.js
@@ -31,6 +31,7 @@ class GatewayWsManager extends EventEmitter {
     this.maxReconnectAttempts = Number(options.maxReconnectAttempts || process.env.GATEWAY_WS_MAX_RECONNECT_ATTEMPTS || 0); // 0 = unlimited
     this.reconnectDelay = options.reconnectDelay || 1000;
     this.reconnectBackoff = options.reconnectBackoff || 2;
+    this.maxReconnectDelay = options.maxReconnectDelay || 60000; // Cap backoff at 60s
 
     // Store origin for reconnection
     this._lastOrigin = options.origin || 'http://localhost:3000';
@@ -132,14 +133,14 @@ class GatewayWsManager extends EventEmitter {
     if (this._manualClose) return;
     if (this._reconnectTimer) return;
 
-    if (this.maxReconnectAttempts > 0 && this.reconnectAttempts >= this.maxReconnectAttempts) {
-      this.emit('reconnect-failed', new Error(`Max reconnection attempts (${this.maxReconnectAttempts}) reached. Continuing with capped backoff.`));
-    }
-
     this.reconnectAttempts++;
     const baseDelay = this.reconnectDelay * Math.pow(this.reconnectBackoff, this.reconnectAttempts - 1);
-    const jitter = Math.floor(Math.random() * 300);
-    const delay = baseDelay + jitter;
+    const delay = Math.min(baseDelay, this.maxReconnectDelay) + Math.floor(Math.random() * 300);
+
+    if (this.maxReconnectAttempts > 0 && this.reconnectAttempts > this.maxReconnectAttempts) {
+      this.emit('reconnect-failed', new Error(`Max reconnection attempts (${this.maxReconnectAttempts}) reached`));
+      return;
+    }
 
     this.emit('reconnecting', this.reconnectAttempts, delay);
 


### PR DESCRIPTION
Fixes #446. Caps the WebSocket reconnect backoff delay at 60 seconds max (with jitter) to prevent exponential backoff from growing unbounded during prolonged connectivity issues. Also fixes an off-by-one in the max reconnect attempts check (was >= now >), and adds early return after emitting reconnect-failed to prevent scheduling a reconnect after max attempts are exceeded.