### PR TITLE
fix(ws): infer GATEWAY_WS_ORIGIN from CORS_ORIGIN if not set

### DIFF
--- a/server.js
+++ b/server.js
@@ -889,7 +889,11 @@ function buildGatewayDeviceAuth({ nonce, scopes }) {
   const signature = base64UrlEncode(crypto.sign(null, Buffer.from(payload, 'utf8'), crypto.createPrivateKey(identity.privateKeyPem)));
   return { id: identity.deviceId, publicKey: identity.publicKey, signature, signedAt, nonce };
 }
-const gatewayWsOrigin = process.env.GATEWAY_WS_ORIGIN || 'http://localhost:3000';
+// Infer GATEWAY_WS_ORIGIN from CORS_ORIGIN if not explicitly set
+const configuredGatewayWsOrigin = process.env.GATEWAY_WS_ORIGIN;
+const corsOrigin = process.env.CORS_ORIGIN || process.env.ALLOWED_ORIGINS || '';
+const firstCorsOrigin = corsOrigin.split(',')[0].trim();
+const gatewayWsOrigin = configuredGatewayWsOrigin || firstCorsOrigin || 'http://localhost:3000';
 const GATEWAY_URL = process.env.GATEWAY_URL || process.env.OPENCLAW_API_URL || 'http://openclaw.llm.svc.cluster.local:18789';
 const GATEWAY_TOKEN = process.env.GATEWAY_TOKEN || process.env.GATEWAY_AUTH_TOKEN || '';
 const gatewayWsManager = new GatewayWsManager({


### PR DESCRIPTION
## Problem

`GATEWAY_WS_ORIGIN` previously defaulted to `http://localhost:3000`. When miso-chat is deployed behind a reverse proxy with a different external URL (e.g. `https://miso-chat.jory.dev`), the gateway rejects the WebSocket connection with "origin not allowed" because `localhost:3000` isn't in its allowed origins list.

## Fix

Instead of hardcoding `localhost:3000`, the code now checks `CORS_ORIGIN` (or `ALLOWED_ORIGINS`) as a fallback before falling back to `localhost:3000`:

```js
const configuredGatewayWsOrigin = process.env.GATEWAY_WS_ORIGIN;
const corsOrigin = process.env.CORS_ORIGIN || process.env.ALLOWED_ORIGINS || '';
const firstCorsOrigin = corsOrigin.split(',')[0].trim();
const gatewayWsOrigin = configuredGatewayWsOrigin || firstCorsOrigin || 'http://localhost:3000';
```

This means deployments that already set `CORS_ORIGIN` don't need to also set `GATEWAY_WS_ORIGIN` explicitly.

Explicit `GATEWAY_WS_ORIGIN` still takes precedence if set (for cases where WS origin needs to differ from CORS origin).