### PR TITLE
fix(Dockerfile): use npm ci with lockfile for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24-alpine
 WORKDIR /app
-COPY package.json ./
-RUN npm install --omit=dev
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
 COPY . .
 ENV NODE_ENV=production
 EXPOSE 3000


### PR DESCRIPTION
Refs #462. Addresses one finding from the weekly audit: **P1 — Docker image builds are not lockfile-reproducible**

## Problem

The Dockerfile copied only  and ran `npm install --omit=dev`, bypassing `package-lock.json` during dependency installation. This allowed dependency drift between CI (which uses `npm ci`) and production container builds.



## Fix

Copy both `package.json` and `package-lock.json`, use `npm ci --omit=dev`:



This ensures Docker builds resolve dependencies from the same lockfile as CI, making release artifacts reproducible.

## Scope

Single-file change (Dockerfile). No behavioral changes to the application. No new dependencies.