### PR TITLE
fix: remove non-scope entries from REQUESTED_GATEWAY_SCOPES

### DIFF
--- a/server.js
+++ b/server.js
@@ -803,7 +803,7 @@ const GATEWAY_WS_CLIENT_ID = process.env.GATEWAY_WS_CLIENT_ID || 'webchat-ui';
 const GATEWAY_WS_CLIENT_MODE = process.env.GATEWAY_WS_CLIENT_MODE || 'webchat';
 const GATEWAY_DEVICE_IDENTITY_PATH = process.env.GATEWAY_DEVICE_IDENTITY_PATH || path.join(process.env.HOME || '/home/node', '.openclaw', 'identity', 'device.json');
 const GATEWAY_WS_WAIT_CHALLENGE_MS = Number(process.env.GATEWAY_WS_WAIT_CHALLENGE_MS || 1200);
-const REQUESTED_GATEWAY_SCOPES = ['operator.read','operator.write','operator.admin','operator.pairing','chat.send','sessions.send','sessions.list','sessions.history'];
+const REQUESTED_GATEWAY_SCOPES = ['operator.read','operator.write','operator.admin','operator.pairing'];
 const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
 let cachedGatewayDeviceIdentity = null;
 


### PR DESCRIPTION
## Problem

The OpenClaw gateway rejects connections from miso-chat because `REQUESTED_GATEWAY_SCOPES` includes method names that are not valid scope identifiers.

When miso-chat connects to the gateway, it sends these scope names in the device auth payload. The gateway validates each requested scope against its known scope registry and rejects any unknown scope, causing the connection to fail.

## Root Cause

Line 806 in `server.js` defined:

```js
const REQUESTED_GATEWAY_SCOPES = ['operator.read','operator.write','operator.admin','operator.pairing','chat.send','sessions.send','sessions.list','sessions.history'];
```

The entries `chat.send`, `sessions.send`, `sessions.list`, and `sessions.history` are **gateway method names**, not scope names. OpenClaw's valid scopes are only:

- `operator.admin`
- `operator.read`
- `operator.write`
- `operator.approvals`
- `operator.pairing`

Methods like `chat.send` and `sessions.list` map to scopes internally (e.g. `chat.send` → `operator.write`, `sessions.list` → `operator.read`), but they cannot be used as scope identifiers in the device auth payload.

## Fix

Remove the four non-scope entries from `REQUESTED_GATEWAY_SCOPES`. The remaining scopes (`operator.admin`, `operator.read`, `operator.write`, `operator.pairing`) cover all the methods miso-chat needs:

- `sessions.list` → covered by `operator.read`
- `chat.send` → covered by `operator.write`
- `sessions.send` → covered by `operator.write`
- `sessions.history` → covered by `operator.read` (via `sessions.get`, `chat.history`, etc.)

Refs #465