### PR TITLE
fix: bump package.json to 0.4.12 and add release version consistency check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,3 +162,27 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           DEPLOY_HEALTH_URL: ${{ secrets.RELEASE_SMOKE_HEALTH_URL }}
         run: ./scripts/release-readiness-check.sh
+
+  version-consistency:
+    name: Version consistency check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Compare release tag with package.json version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          TAG_VERSION="${RELEASE_TAG#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "Release tag: ${TAG_VERSION}"
+          echo "package.json: ${PKG_VERSION}"
+          if [[ "${TAG_VERSION}" != "${PKG_VERSION}" ]]; then
+            echo "❌ Version drift detected: release tag ${TAG_VERSION} does not match package.json ${PKG_VERSION}"
+            echo "Update package.json to ${TAG_VERSION} using: npm version ${TAG_VERSION} --no-git-tag-version"
+            exit 1
+          fi
+          echo "✅ Release tag matches package.json version: ${TAG_VERSION}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miso-chat",
-  "version": "0.4.10",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miso-chat",
-      "version": "0.4.10",
+      "version": "0.4.12",
       "dependencies": {
         "@capacitor/android": "^8.1.0",
         "@capacitor/app": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miso-chat",
-  "version": "0.4.10",
+  "version": "0.4.12",
   "private": true,
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Fixes #462 — addresses the remaining P1 finding from the weekly tech debt audit: release/versioning drift.

### Changes

1. **Bumped `package.json`** from `0.4.10` to `0.4.12` to match the latest release tag (`0.4.12`). This was the concrete P1 finding — the app health endpoint and Android OTA manifest were reporting version `0.4.10` while releases were tagged `0.4.12`.

2. **Added a `version-consistency` CI job** in `.github/workflows/release.yaml` that compares the release tag with `package.json` version at release time. If they do not match, the build fails with a clear error message directing the operator to run `npm version <TAG> --no-git-tag-version`.

### Audit #462 Context

The original audit found that release tags and GitHub releases were ahead of the app version embedded in the repo (`0.4.12` vs `0.4.10`). This PR fixes the immediate drift and adds a guardrail so it cannot recur silently.

Other P1 findings from the audit have already been addressed:
- ✅ Docker builds lockfile-reproducible (PR #485)
- ✅ CI/test configuration runs all tests (PR #485)
- ✅ Gateway privilege scope reduced (merged previously)
- ✅ Realtime/health/SSE contract defined and tested (PR #485)

### Validation

- `npm test` — 55 pass, 0 fail
- `npm run lint` — passed