### PR TITLE
fix: resend pending WS requests on gateway reconnect + add tests & docs

### DIFF
--- a/REALTIME-CONTRACT.md
+++ b/REALTIME-CONTRACT.md
@@ -1,0 +1,132 @@
+# Realtime Health, SSE & WebSocket Contract
+
+This document describes the realtime lifecycle contract between the miso-chat
+backend (`server.js`, `lib/gateway-ws.js`) and frontend (`public/index.html`).
+It covers health reporting, SSE event forwarding, and gateway WebSocket reconnect semantics.
+
+## 1. `/api/health` — Backend health endpoint
+
+**GET /api/health** (no auth required) returns a JSON object with three sections:
+
+```jsonc
+{
+  "status": "healthy",                    // always "healthy" for the HTTP server itself
+  "version": "0.5.0",                     // app version string
+  "timestamp": "2026-05-18T11:00:00.000Z",
+
+  "gatewayWs": {
+    "connected": true,                    // boolean — protocol-level Gateway WS connected
+    "connecting": false,                  // boolean — currently attempting to connect
+    "reconnectAttempts": 2,               // number — consecutive reconnect attempts
+    "pendingRequests": 0,                 // number — requests waiting for response
+    "pendingForRecovery": 0,              // number — requests queued for resend on reconnect
+    "lastError": null,                    // string | null — last error message
+    "lastClose": {                        // object | null — last close event details
+      "code": 1006,
+      "reason": "abnormal closure",
+      "at": "2026-05-18T10:59:30.000Z"
+    }
+  },
+
+  "realtime": {
+    "state": "healthy",                   // one of: "healthy" | "reconnecting" | "degraded" | "disconnected"
+    "message": "Gateway WebSocket connected"
+  }
+}
+```
+
+### Realtime state values
+
+| State | Meaning |
+|---|---|
+| `healthy` | Gateway WS is connected (`isConnected() === true`) |
+| `reconnecting` | Gateway WS disconnected, reconnect attempts > 0 |
+| `degraded` | Gateway WS not connected and there was a recent error |
+| `disconnected` | Gateway WS not connected, no active reconnect attempt |
+
+The frontend reads this endpoint (via `refreshBackendHealth()`) to update its
+online/offline UI indicator.
+
+## 2. SSE Event Forwarding — `/api/events`
+
+**GET /api/events** (auth required) opens a Server-Sent Events connection that
+forwards gateway WebSocket events to the browser.
+
+### Lifecycle
+
+1. Client creates `new EventSource('/api/events')`.
+2. Server sends `data: {"event":"connected","data":{"ok":true},"timestamp":...}` on open.
+3. Gateway WS manager emits `'gateway-event'` → server broadcasts to all SSE clients.
+4. On SSE error, client waits 5 s then retries (single timer prevents duplicates).
+5. On explicit close (`onclose`), client does **not** auto-reconnect.
+
+### Duplicate prevention
+
+`connectEventSource()` always:
+- Closes any existing `EventSource` instance before creating a new one.
+- Clears any pending reconnect timer (`sseReconnectTimer`) to avoid duplicate reconnection attempts.
+
+## 3. Gateway WebSocket Pending Request Semantics
+
+When the persistent Gateway WS connection drops, in-flight requests are handled as follows:
+
+### On disconnect (while connected)
+
+1. `_storePendingForRecovery()` — copies all `pendingRequests` entries into `_recoveryPending`.
+2. Each entry stores `{ resolve, reject, timeout, frameData }` where `frameData` is the original
+   `{ type, id, method, params }` frame JSON that was sent.
+
+### On reconnect (after successful reconnection)
+
+1. `_recoverPendingRequests()` is called from the `'connected'` handler in `connect()`.
+2. For each recovered request with valid `frameData`:
+   - The original frame is **resent** over the new socket connection.
+   - A new timeout (`recoveredRequestTimeoutSeconds`, default 30 s) is set.
+   - The entry is restored to `pendingRequests` so responses are matched correctly.
+3. Requests without `frameData` (edge case) are rejected with `'Request could not be resent after reconnect'`.
+
+### Configuration
+
+- `recoveredRequestTimeoutSeconds` — timeout for recovered requests (seconds).
+  - Constructor option: `{ recoveredRequestTimeoutSeconds: 60 }`
+  - Environment variable: `GATEWAY_WS_RECOVERED_REQUEST_TIMEOUT_S=60`
+  - Default: `30`
+
+### Idempotency expectations
+
+Clients should design their gateway method calls to be idempotent when possible,
+since resent requests will arrive with the same request ID. The gateway treats
+duplicate IDs as retries of the same logical operation.
+
+## 4. Frontend Fallback Behavior
+
+When the gateway is unavailable:
+
+1. **Health polling** — `refreshBackendHealth()` runs periodically (on SSE reconnect,
+   queue retry scheduling, and manual checks). It reads `/api/health` to determine
+   if the gateway is reconnecting or fully disconnected.
+2. **Message queueing** — Failed sends are queued in `localStorage` (`miso.pendingQueue`).
+3. **SSE fallback** — On SSE error, `startHistoryPolling()` begins polling session history
+   as a degraded real-time substitute.
+4. **UI indicators** — The frontend displays:
+   - `"Reconnecting to gateway…"` when health reports reconnect attempts > 0.
+   - `"Gateway handshake failed (backend disconnected)"` when fully disconnected.
+   - A queued-message count badge when pending items exist.
+
+## 5. Quick Reference
+
+| Component | File | Key Methods |
+|---|---|---|
+| Health endpoint | `server.js` | `/api/health` GET handler |
+| WS manager | `lib/gateway-ws.js` | `connect()`, `send()`, `_recoverPendingRequests()` |
+| SSE forwarder | `server.js` | `/api/events` handler, `broadcastToSseClients()` |
+| Frontend SSE | `public/index.html` | `connectEventSource()`, `refreshBackendHealth()` |
+
+## 6. Tests
+
+| Test file | Covers |
+|---|---|
+| `tests/realtime-health-contract.test.js` | `/api/health` payload fields and structure |
+| `tests/sse-reconnect-contract.test.js` | SSE duplicate prevention and reconnect behavior |
+| `tests/gateway-ws-reconnect.test.js` | WS manager initial state, disconnect handling, recovery |
+| `tests/gateway-ws-pending-resend.test.js` | Frame data storage, resend on reconnect, timeout config |

--- a/lib/gateway-ws.js
+++ b/lib/gateway-ws.js
@@ -40,6 +40,11 @@ class GatewayWsManager extends EventEmitter {
     this._recoveryPending = null; // Store pending requests for recovery after reconnection
     this.requestIdCounter = 0;
 
+    // Timeout for recovered (resend) requests in seconds
+    this.recoveredRequestTimeoutSeconds = Number(
+      options.recoveredRequestTimeoutSeconds || process.env.GATEWAY_WS_RECOVERED_REQUEST_TIMEOUT_S || 30,
+    );
+
     this._connectId = null;
     this._challengeWaitTimer = null;
     this._reconnectTimer = null;
@@ -121,12 +126,32 @@ class GatewayWsManager extends EventEmitter {
    * @private
    */
   _recoverPendingRequests() {
-    if (!this._recoveryPending || this._recoveryPending.size === 0) return;
+    if (!this._recoveryPending || this._recoveryPending.size === 0) {
+      this._recoveryPending = null;
+      return;
+    }
 
     for (const [id, pending] of this._recoveryPending.entries()) {
-      this.pendingRequests.set(id, pending);
+      const frameData = pending.frameData;
+      clearTimeout(pending.timeout);
+
+      if (!frameData || !this.ws || this.ws.readyState !== 1) {
+        // No frame data to resend or socket not ready — fail the request
+        pending.reject?.(new Error('Request could not be resent after reconnect'));
+        continue;
+      }
+
+      const timeout = setTimeout(() => {
+        if (this.pendingRequests.has(id)) {
+          this.pendingRequests.delete(id);
+          pending.reject?.(new Error(`Recovered request ${frameData.method} (${id}) timed out after ${this.recoveredRequestTimeoutSeconds}s`));
+        }
+      }, this.recoveredRequestTimeoutSeconds * 1000);
+
+      this.pendingRequests.set(id, { resolve: pending.resolve, reject: pending.reject, timeout });
+      this.ws.send(JSON.stringify(frameData));
     }
-    this._recoveryPending.clear();
+    this._recoveryPending = null;
   }
 
   _scheduleReconnect(origin) {
@@ -350,7 +375,12 @@ class GatewayWsManager extends EventEmitter {
         }
       }, timeoutSeconds * 1000);
 
-      this.pendingRequests.set(id, { resolve, reject, timeout });
+      this.pendingRequests.set(id, {
+        resolve,
+        reject,
+        timeout,
+        frameData: { type: 'req', id, method, params },
+      });
 
       this.ws.send(JSON.stringify({
         type: 'req',

--- a/tests/gateway-ws-pending-resend.test.js
+++ b/tests/gateway-ws-pending-resend.test.js
@@ -1,0 +1,171 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('events');
+
+// Mock WebSocket to avoid actual network connections
+class MockWebSocket extends EventEmitter {
+  constructor(url, options) {
+    super();
+    this.url = url;
+    this.readyState = 0; // CONNECTING
+    this._mockOpenDelay = options?.mockOpenDelay || 10;
+    this._sentFrames = [];
+    setTimeout(() => {
+      this.readyState = 1; // OPEN
+      this.emit('open');
+    }, this._mockOpenDelay);
+  }
+
+  send(data, callback) {
+    if (this.readyState === 1) {
+      this._sentFrames.push(data);
+      if (callback) callback(null);
+    } else {
+      if (callback) callback(new Error('WebSocket not open'));
+    }
+  }
+
+  close() {
+    this.readyState = 3; // CLOSED
+    this.emit('close', 1000, 'normal');
+  }
+
+  getSentFrames() {
+    return [...this._sentFrames];
+  }
+}
+
+// Patch the ws module before requiring GatewayWsManager
+const Module = require('module');
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function(id) {
+  if (id === 'ws') {
+    return MockWebSocket;
+  }
+  return originalRequire.apply(this, arguments);
+};
+
+const { GatewayWsManager } = require('../lib/gateway-ws');
+
+// Restore original require
+Module.prototype.require = originalRequire;
+
+test('GatewayWsManager stores frameData in pending requests', () => {
+  const manager = new GatewayWsManager();
+
+  // Simulate being connected
+  manager.connected = true;
+  manager.ws = { readyState: 1, send: () => {} };
+
+  let resolveFn, rejectFn;
+  const promise = new Promise((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+
+  const id = manager.createRequestId('test');
+  const timeout = setTimeout(() => {}, 50);
+  manager.pendingRequests.set(id, {
+    resolve: resolveFn,
+    reject: rejectFn,
+    timeout,
+    frameData: { type: 'req', id, method: 'chat.send', params: { sessionKey: 'test' } },
+  });
+
+  const pending = manager.pendingRequests.get(id);
+  assert.ok(pending.frameData, 'frameData should be stored in pending request');
+  assert.equal(pending.frameData.method, 'chat.send', 'frameData.method should match');
+  assert.deepStrictEqual(pending.frameData.params, { sessionKey: 'test' }, 'frameData.params should match');
+});
+
+test('GatewayWsManager resends frames on reconnect recovery', async () => {
+  const mockWs = new MockWebSocket('ws://test', { mockOpenDelay: 100 });
+  // Manually make the mock WebSocket OPEN before using it
+  mockWs.readyState = 1;
+
+  const manager = new GatewayWsManager({ wsUrl: 'ws://test' });
+
+  // Simulate connected state with pending request
+  manager.connected = true;
+  manager.ws = mockWs;
+
+  let resolveFn;
+  const promise = new Promise((resolve) => { resolveFn = resolve; });
+
+  const id = manager.createRequestId('test');
+  const timeout = setTimeout(() => {}, 50);
+  manager.pendingRequests.set(id, {
+    resolve: resolveFn,
+    reject: () => {},
+    timeout,
+    frameData: { type: 'req', id, method: 'chat.send', params: { sessionKey: 'test' } },
+  });
+
+  // Simulate disconnect (store for recovery)
+  manager._storePendingForRecovery();
+  assert.equal(manager.getPendingRequestCount(), 0);
+  assert.equal(manager.getPendingForRecoveryCount(), 1);
+
+  // Simulate reconnect — mockWs is already OPEN
+  manager.connected = true;
+  manager.ws = mockWs;
+
+  // Recover pending requests
+  manager._recoverPendingRequests();
+
+  assert.equal(manager.getPendingRequestCount(), 1, 'should have 1 recovered pending request');
+  assert.equal(manager.getPendingForRecoveryCount(), 0, 'recovery pending should be cleared');
+
+  // Verify the frame was resent
+  const sentFrames = mockWs.getSentFrames();
+  const resendFrame = JSON.parse(sentFrames[sentFrames.length - 1]);
+  assert.equal(resendFrame.method, 'chat.send', 'resend frame should have correct method');
+  assert.deepStrictEqual(resendFrame.params, { sessionKey: 'test' }, 'resend frame should have correct params');
+
+  // Resolve the pending request to prevent unhandled rejection
+  resolveFn({ ok: true });
+});
+
+test('GatewayWsManager fails pending requests when no frameData on recovery', async () => {
+  const manager = new GatewayWsManager();
+
+  // Set up recovery with a pending request that has no frameData
+  let rejectedWith = null;
+  const promise = new Promise((resolve, reject) => {
+    const id = manager.createRequestId('test');
+    const timeout = setTimeout(() => {}, 50);
+    manager._recoveryPending = new Map([[id, { resolve: () => {}, reject: (err) => { rejectedWith = err.message; }, timeout }]]);
+  });
+
+  // Catch unhandled rejection
+  promise.catch(() => {});
+
+  // Recover — should fail the request since no frameData
+  manager._recoverPendingRequests();
+
+  await new Promise(r => setTimeout(r, 20));
+  assert.ok(rejectedWith && rejectedWith.includes('could not be resent'),
+    `should reject with resend error, got: ${rejectedWith}`);
+});
+
+test('GatewayWsManager configures recoveredRequestTimeoutSeconds from options', () => {
+  const manager = new GatewayWsManager({ recoveredRequestTimeoutSeconds: 60 });
+  assert.equal(manager.recoveredRequestTimeoutSeconds, 60, 'should use custom timeout');
+});
+
+test('GatewayWsManager configures recoveredRequestTimeoutSeconds from env', () => {
+  const prev = process.env.GATEWAY_WS_RECOVERED_REQUEST_TIMEOUT_S;
+  process.env.GATEWAY_WS_RECOVERED_REQUEST_TIMEOUT_S = '45';
+  const manager = new GatewayWsManager({});
+  assert.equal(manager.recoveredRequestTimeoutSeconds, 45, 'should use env var timeout');
+  if (prev !== undefined) {
+    process.env.GATEWAY_WS_RECOVERED_REQUEST_TIMEOUT_S = prev;
+  } else {
+    delete process.env.GATEWAY_WS_RECOVERED_REQUEST_TIMEOUT_S;
+  }
+});
+
+test('GatewayWsManager defaults recoveredRequestTimeoutSeconds to 30', () => {
+  const manager = new GatewayWsManager({});
+  assert.equal(manager.recoveredRequestTimeoutSeconds, 30, 'should default to 30s');
+});

--- a/tests/gateway-ws-reconnect.test.js
+++ b/tests/gateway-ws-reconnect.test.js
@@ -125,12 +125,20 @@ test('GatewayWsManager stores pending requests for recovery on disconnect', () =
 test('GatewayWsManager recovers pending requests after reconnect', () => {
   const manager = new GatewayWsManager();
   
-  // Set up pending for recovery
+  // Provide a mock WebSocket so the resend path works
+  manager.ws = { readyState: 1, send: () => {} };
+  manager.connected = true;
+  
   let pendingResolve;
   const promise = new Promise((resolve) => { pendingResolve = resolve; });
   const id = manager.createRequestId('test');
   const timeout = setTimeout(() => {}, 50);
-  manager._recoveryPending = new Map([[id, { resolve: pendingResolve, reject: () => {}, timeout }]]);
+  manager._recoveryPending = new Map([[id, { 
+    resolve: pendingResolve, 
+    reject: () => {}, 
+    timeout,
+    frameData: { type: 'req', id, method: 'test', params: {} },
+  }]]);
   
   assert.equal(manager.getPendingForRecoveryCount(), 1, 'should have 1 pending for recovery');
   


### PR DESCRIPTION
## Summary

Fixes the gateway WebSocket manager's pending request handling on reconnect. Previously, `_recoverPendingRequests()` restored pending request callbacks to the map but never actually resent the original frames — they would just wait until timeout. Now the original frame data is stored alongside each pending request and actively resent over the new connection after reconnection.

## Changes

### `lib/gateway-ws.js`
- **Store frame data**: `send()` now stores `{ type, id, method, params }` in each pending entry as `frameData`
- **Active resend on reconnect**: `_recoverPendingRequests()` now resends each frame over the new socket connection instead of just restoring callbacks
- **Recovery timeout config**: Added `recoveredRequestTimeoutSeconds` (env: `GATEWAY_WS_RECOVERED_REQUEST_TIMEOUT_S`, default 30s) for recovered request timeouts
- **Fixed mock compatibility**: Changed `WebSocket.OPEN` reference to numeric `1` for test mock compatibility

### Tests (`tests/gateway-ws-pending-resend.test.js`)
- Pending requests store frameData
- Frames are actively resent on reconnect recovery
- Requests without frameData are properly rejected
- Config via options, env var, and defaults

### Documentation (`REALTIME-CONTRACT.md`)
- Documents the full realtime health/SSE/WS contract for operators and future maintainers

## Acceptance Criteria

| Criteria | Status |
|---|---|
| `/api/health` exposes gateway/realtime state | ✅ Already implemented |
| SSE reconnect cannot leave duplicate EventSource | ✅ Already implemented |
| Gateway WS pending requests have deterministic resend behavior | ✅ **Fixed** |
| Tests cover health payload, SSE dedup, WS reconnect, resend | ✅ Added new tests + updated existing |
| README/docs describe the realtime contract | ✅ Added REALTIME-CONTRACT.md |

Fixes #472