### PR TITLE
fix: harden SSRF protections — final URL validation, redirect count fix, IPv6 broadcast coverage

### DIFF
--- a/lib/ssrf-validation.js
+++ b/lib/ssrf-validation.js
@@ -6,6 +6,7 @@
  * - Direct private/loopback/hostnames (localhost, .local, 10.x, 192.168.x, etc.)
  * - DNS rebinding: resolves hostnames and checks if they resolve to private IPs
  * - IPv4 and IPv6 private ranges including link-local and unique-local
+ * - IPv6 unspecified address (::) and IPv4 broadcast (255.255.255.255)
  */
 
 const dns = require('dns');
@@ -31,6 +32,7 @@ function isPrivateIPv4(hostname) {
     || (a === 169 && b === 254)
     || (a === 172 && b >= 16 && b <= 31)
     || (a === 192 && b === 168)
+    || (a === 255 && b === 255) // IPv4 broadcast
   );
 }
 
@@ -42,9 +44,10 @@ function isPrivateIPv6(hostname) {
   return (
     normalized === '::1'
     || normalized === '0:0:0:0:0:0:0:1'
-    || normalized.startsWith('fe80:')
-    || normalized.startsWith('fc')
-    || normalized.startsWith('fd')
+    || normalized === '::' // IPv6 unspecified
+    || normalized.startsWith('fe80:') // Link-local
+    || normalized.startsWith('fc') // Unique-local (fc00::/7)
+    || normalized.startsWith('fd') // Unique-local (fd00::/8)
   );
 }
 

--- a/server.js
+++ b/server.js
@@ -1317,7 +1317,7 @@ app.get('/api/link-preview', isAuthenticated, async (req, res) => {
   const timeoutHandle = setTimeout(() => controller.abort(), LINK_PREVIEW_TIMEOUT_MS);
 
   try {
-    while (redirectCount <= MAX_REDIRECTS) {
+    while (redirectCount < MAX_REDIRECTS) {
       const parsedUrl = new URL(currentUrl);
 
       // Validate each hop's hostname (with DNS resolution for rebinding protection)
@@ -1358,6 +1358,12 @@ app.get('/api/link-preview', isAuthenticated, async (req, res) => {
     if (!finalResponse || !finalResponse.ok) {
       const status = finalResponse?.status || 502;
       return res.status(status >= 300 && status < 400 ? 400 : 502).json({ error: `Upstream request failed (${status})` });
+    }
+
+    // Validate the final resolved URL is not a private host (catches last-hop SSRF)
+    const finalUrlParsed = finalResponse.url ? new URL(finalResponse.url) : null;
+    if (finalUrlParsed && isForbiddenLinkPreviewHost(finalUrlParsed.hostname, { resolveDns: true })) {
+      return res.status(400).json({ error: 'Final redirect target is a local/private host' });
     }
 
     const contentType = String(finalResponse.headers.get('content-type') || '').toLowerCase();

--- a/tests/ssrf-link-preview.test.js
+++ b/tests/ssrf-link-preview.test.js
@@ -31,6 +31,10 @@ test('isForbiddenLinkPreviewHost blocks private IPv4 addresses', () => {
   assert.equal(isForbiddenLinkPreviewHost('192.168.255.255'), true);
 });
 
+test('isForbiddenLinkPreviewHost blocks IPv4 broadcast address', () => {
+  assert.equal(isForbiddenLinkPreviewHost('255.255.255.255'), true);
+});
+
 test('isForbiddenLinkPreviewHost blocks private IPv6 addresses', () => {
   assert.equal(isForbiddenLinkPreviewHost('::1'), true);
   assert.equal(isForbiddenLinkPreviewHost('0:0:0:0:0:0:0:1'), true);
@@ -38,6 +42,10 @@ test('isForbiddenLinkPreviewHost blocks private IPv6 addresses', () => {
   assert.equal(isForbiddenLinkPreviewHost('fe80::1'), true);
   assert.equal(isForbiddenLinkPreviewHost('fc00::1'), true);
   assert.equal(isForbiddenLinkPreviewHost('fd00::1'), true);
+});
+
+test('isForbiddenLinkPreviewHost blocks IPv6 unspecified address', () => {
+  assert.equal(isForbiddenLinkPreviewHost('::'), true);
 });
 
 test('isForbiddenLinkPreviewHost allows public hostnames', () => {
@@ -83,4 +91,62 @@ test('hostResolvesToPrivate handles unresolvable hostnames gracefully', () => {
   // Non-existent domain should not throw, should return false (can't confirm private)
   const result = hostResolvesToPrivate('this-domain-definitely-does-not-exist-12345.com');
   assert.ok(typeof result === 'boolean', 'should return a boolean for unresolvable domains');
+});
+
+// ---- Acceptance criteria: IPv6 loopback and private cases ----
+
+test('IPv6 loopback ::1 is blocked', () => {
+  assert.equal(isForbiddenLinkPreviewHost('::1'), true);
+});
+
+test('IPv6 link-local fe80::/10 range is blocked', () => {
+  assert.equal(isForbiddenLinkPreviewHost('fe80::1'), true);
+  assert.equal(isForbiddenLinkPreviewHost('fe80::abcd'), true);
+});
+
+test('IPv6 unique-local fc00::/7 range is blocked', () => {
+  assert.equal(isForbiddenLinkPreviewHost('fc00::1'), true);
+  assert.equal(isForbiddenLinkPreviewHost('fd00::1'), true);
+});
+
+test('IPv6 unspecified :: is blocked', () => {
+  assert.equal(isForbiddenLinkPreviewHost('::'), true);
+});
+
+// ---- Acceptance criteria: Direct private targets ----
+
+test('Direct private IPv4 targets are blocked', () => {
+  assert.equal(isForbiddenLinkPreviewHost('10.0.0.1'), true);
+  assert.equal(isForbiddenLinkPreviewHost('192.168.1.1'), true);
+  assert.equal(isForbiddenLinkPreviewHost('172.16.0.1'), true);
+  assert.equal(isForbiddenLinkPreviewHost('127.0.0.1'), true);
+  assert.equal(isForbiddenLinkPreviewHost('169.254.169.254'), true); // cloud metadata
+});
+
+test('Public IPv4 addresses are allowed', () => {
+  assert.equal(isForbiddenLinkPreviewHost('8.8.8.8'), false);
+  assert.equal(isForbiddenLinkPreviewHost('1.1.1.1'), false);
+  assert.equal(isForbiddenLinkPreviewHost('142.250.80.46'), false); // google.com
+});
+
+// ---- Integration-style: valid public redirect scenario ----
+
+test('Public hostnames are allowed for preview (simulates valid public redirect)', () => {
+  // These represent what would be validated at each hop of a public redirect chain
+  assert.equal(isForbiddenLinkPreviewHost('httpbin.org'), false);
+  assert.equal(isForbiddenLinkPreviewHost('redirect.example.com'), false);
+  assert.equal(isForbiddenLinkPreviewHost('example.com'), false);
+});
+
+// ---- Edge cases ----
+
+test('isForbiddenLinkPreviewHost handles case insensitivity', () => {
+  assert.equal(isForbiddenLinkPreviewHost('LOCALHOST'), true);
+  assert.equal(isForbiddenLinkPreviewHost('LoCaLhOsT'), true);
+  assert.equal(isForbiddenLinkPreviewHost('EXAMPLE.COM'), false);
+});
+
+test('isForbiddenLinkPreviewHost handles .localhost subdomains', () => {
+  assert.equal(isForbiddenLinkPreviewHost('foo.localhost'), true);
+  assert.equal(isForbiddenLinkPreviewHost('bar.foo.localhost'), true);
 });


### PR DESCRIPTION
Addresses remaining gaps from #473 (Refs #489):

## Changes

1. **Final resolved URL validation** — After the redirect loop completes, validate `finalResponse.url` against private hosts. The previous implementation only validated each hop *before* fetching but never checked the final URL, allowing last-hop SSRF to a private IP.

2. **Off-by-one fix in redirect count** — Changed `while (redirectCount <= MAX_REDIRECTS)` to `while (redirectCount < MAX_REDIRECTS)`. The old condition allowed 6 hops instead of the intended 5 (when MAX_REDIRECTS=5).

3. **IPv6 unspecified address (`::`) blocking** — Added `::` to `isPrivateIPv6()` to block the IPv6 unspecified/all-zeros address.

4. **IPv4 broadcast address blocking** — Added `255.255.255.255` to `isPrivateIPv4()`.

## Tests

- 22 unit tests covering all acceptance criteria from #473
- Direct private targets (localhost, 127.x, 10.x, 192.168.x, etc.)
- IPv6 loopback/private (::1, fe80:, fc00:, fd00:, ::)
- IPv4 broadcast (255.255.255.255)
- Public hostname allowance (example.com, github.com, public IPs)
- Valid public redirect simulation
- Case insensitivity and edge cases

## Verification

```bash
node --test tests/ssrf-link-preview.test.js
# 22 tests pass, 0 failures
```