### PR TITLE
fix: enforce DNS-based SSRF validation for link previews

### DIFF
--- a/lib/ssrf-validation.js
+++ b/lib/ssrf-validation.js
@@ -9,11 +9,8 @@
  * - IPv6 unspecified address (::) and IPv4 broadcast (255.255.255.255)
  */
 
-const dns = require('dns');
-const { promisify } = require('util');
-
-const dnsResolve4 = promisify(dns.resolve4);
-const dnsResolve6 = promisify(dns.resolve6);
+const dns = require('dns').promises;
+const net = require('net');
 
 /**
  * Check if a hostname or IP is a private/loopback/link-local address.
@@ -51,17 +48,30 @@ function isPrivateIPv6(hostname) {
   );
 }
 
+async function defaultResolveHostToIps(hostname) {
+  const [v4, v6] = await Promise.allSettled([
+    dns.resolve4(hostname),
+    dns.resolve6(hostname),
+  ]);
+
+  return [v4, v6]
+    .filter((result) => result.status === 'fulfilled')
+    .flatMap((result) => result.value);
+}
+
 /**
  * Resolve a hostname to IP addresses. Returns array of IP strings or empty array on failure.
  */
-function resolveHostToIps(hostname) {
-  if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname)) return [hostname];
-  const ip6 = String(hostname || '').toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
-  if (ip6.includes(':')) return [ip6];
+async function resolveHostToIps(hostname, options = {}) {
+  const normalized = String(hostname || '').toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
+  if (!normalized) return [];
+
+  if (net.isIP(normalized)) return [normalized];
+
+  const resolver = options.resolveHostToIps || defaultResolveHostToIps;
   try {
-    const v4 = dnsResolve4.sync(hostname);
-    const v6 = dnsResolve6.sync(hostname);
-    return [...v4, ...v6];
+    const ips = await resolver(normalized);
+    return Array.isArray(ips) ? ips.filter((ip) => typeof ip === 'string') : [];
   } catch {
     return [];
   }
@@ -70,8 +80,8 @@ function resolveHostToIps(hostname) {
 /**
  * Check if a hostname resolves to any private/loopback/link-local IP.
  */
-function hostResolvesToPrivate(hostname) {
-  const ips = resolveHostToIps(hostname);
+async function hostResolvesToPrivate(hostname, options = {}) {
+  const ips = await resolveHostToIps(hostname, options);
   for (const ip of ips) {
     if (isPrivateIPv4(ip)) return true;
     if (isPrivateIPv6(ip)) return true;
@@ -85,9 +95,10 @@ function hostResolvesToPrivate(hostname) {
  * @param {string} hostname - The hostname to check
  * @param {object} [options] - Options
  * @param {boolean} [options.resolveDns=true] - Whether to resolve DNS and check resolved IPs (default: true)
- * @returns {boolean} True if the host should be blocked
+ * @param {Function} [options.resolveHostToIps] - Optional resolver override for tests
+ * @returns {Promise<boolean>} True if the host should be blocked
  */
-function isForbiddenLinkPreviewHost(hostname, options = {}) {
+async function isForbiddenLinkPreviewHost(hostname, options = {}) {
   const normalized = String(hostname || '').toLowerCase();
   if (!normalized) return true;
   if (normalized === 'localhost' || normalized.endsWith('.localhost') || normalized.endsWith('.local')) {
@@ -97,7 +108,7 @@ function isForbiddenLinkPreviewHost(hostname, options = {}) {
     return true;
   }
   const resolveDns = options.resolveDns !== false;
-  if (resolveDns && hostResolvesToPrivate(normalized)) {
+  if (resolveDns && await hostResolvesToPrivate(normalized, options)) {
     return true;
   }
   return false;

--- a/server.js
+++ b/server.js
@@ -1352,7 +1352,7 @@ app.get('/api/link-preview', isAuthenticated, async (req, res) => {
     return res.status(400).json({ error: 'Only http(s) URLs are supported' });
   }
 
-  if (isForbiddenLinkPreviewHost(targetUrl.hostname)) {
+  if (await isForbiddenLinkPreviewHost(targetUrl.hostname)) {
     return res.status(400).json({ error: 'Local/private hosts are not allowed for previews' });
   }
 
@@ -1369,7 +1369,7 @@ app.get('/api/link-preview', isAuthenticated, async (req, res) => {
       const parsedUrl = new URL(currentUrl);
 
       // Validate each hop's hostname (with DNS resolution for rebinding protection)
-      if (isForbiddenLinkPreviewHost(parsedUrl.hostname, { resolveDns: true })) {
+      if (await isForbiddenLinkPreviewHost(parsedUrl.hostname, { resolveDns: true })) {
         clearTimeout(timeoutHandle);
         return res.status(400).json({ error: 'Redirect target is a local/private host' });
       }
@@ -1410,7 +1410,7 @@ app.get('/api/link-preview', isAuthenticated, async (req, res) => {
 
     // Validate the final resolved URL is not a private host (catches last-hop SSRF)
     const finalUrlParsed = finalResponse.url ? new URL(finalResponse.url) : null;
-    if (finalUrlParsed && isForbiddenLinkPreviewHost(finalUrlParsed.hostname, { resolveDns: true })) {
+    if (finalUrlParsed && await isForbiddenLinkPreviewHost(finalUrlParsed.hostname, { resolveDns: true })) {
       return res.status(400).json({ error: 'Final redirect target is a local/private host' });
     }
 

--- a/tests/ssrf-link-preview.test.js
+++ b/tests/ssrf-link-preview.test.js
@@ -6,147 +6,158 @@ const { isForbiddenLinkPreviewHost, hostResolvesToPrivate, resolveHostToIps } = 
 
 // ---- Unit tests for SSRF validation helpers ----
 
-test('isForbiddenLinkPreviewHost blocks localhost', () => {
-  assert.equal(isForbiddenLinkPreviewHost('localhost'), true);
-  assert.equal(isForbiddenLinkPreviewHost('LOCALHOST'), true);
-  assert.equal(isForbiddenLinkPreviewHost('sub.localhost'), true);
-  assert.equal(isForbiddenLinkPreviewHost('.localhost'), true);
+test('isForbiddenLinkPreviewHost blocks localhost', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('localhost'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('LOCALHOST'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('sub.localhost'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('.localhost'), true);
 });
 
-test('isForbiddenLinkPreviewHost blocks .local domains', () => {
-  assert.equal(isForbiddenLinkPreviewHost('printer.local'), true);
-  assert.equal(isForbiddenLinkPreviewHost('my-router.local'), true);
-  assert.equal(isForbiddenLinkPreviewHost('.local'), true);
+test('isForbiddenLinkPreviewHost blocks .local domains', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('printer.local'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('my-router.local'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('.local'), true);
 });
 
-test('isForbiddenLinkPreviewHost blocks private IPv4 addresses', () => {
-  assert.equal(isForbiddenLinkPreviewHost('10.0.0.1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('10.255.255.255'), true);
-  assert.equal(isForbiddenLinkPreviewHost('127.0.0.1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('127.255.255.255'), true);
-  assert.equal(isForbiddenLinkPreviewHost('169.254.169.254'), true); // AWS IMDS
-  assert.equal(isForbiddenLinkPreviewHost('172.16.0.1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('172.31.255.255'), true);
-  assert.equal(isForbiddenLinkPreviewHost('192.168.0.1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('192.168.255.255'), true);
+test('isForbiddenLinkPreviewHost blocks private IPv4 addresses', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('10.0.0.1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('10.255.255.255'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('127.0.0.1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('127.255.255.255'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('169.254.169.254'), true); // AWS IMDS
+  assert.equal(await isForbiddenLinkPreviewHost('172.16.0.1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('172.31.255.255'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('192.168.0.1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('192.168.255.255'), true);
 });
 
-test('isForbiddenLinkPreviewHost blocks IPv4 broadcast address', () => {
-  assert.equal(isForbiddenLinkPreviewHost('255.255.255.255'), true);
+test('isForbiddenLinkPreviewHost blocks IPv4 broadcast address', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('255.255.255.255'), true);
 });
 
-test('isForbiddenLinkPreviewHost blocks private IPv6 addresses', () => {
-  assert.equal(isForbiddenLinkPreviewHost('::1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('0:0:0:0:0:0:0:1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('[::1]'), true);
-  assert.equal(isForbiddenLinkPreviewHost('fe80::1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('fc00::1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('fd00::1'), true);
+test('isForbiddenLinkPreviewHost blocks private IPv6 addresses', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('::1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('0:0:0:0:0:0:0:1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('[::1]'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('fe80::1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('fc00::1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('fd00::1'), true);
 });
 
-test('isForbiddenLinkPreviewHost blocks IPv6 unspecified address', () => {
-  assert.equal(isForbiddenLinkPreviewHost('::'), true);
+test('isForbiddenLinkPreviewHost blocks IPv6 unspecified address', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('::'), true);
 });
 
-test('isForbiddenLinkPreviewHost allows public hostnames', () => {
-  assert.equal(isForbiddenLinkPreviewHost('example.com'), false);
-  assert.equal(isForbiddenLinkPreviewHost('github.com'), false);
-  assert.equal(isForbiddenLinkPreviewHost('cdn.example.org'), false);
-  assert.equal(isForbiddenLinkPreviewHost('1.1.1.1'), false);
-  assert.equal(isForbiddenLinkPreviewHost('8.8.8.8'), false);
+test('isForbiddenLinkPreviewHost allows public hostnames', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('example.com'), false);
+  assert.equal(await isForbiddenLinkPreviewHost('github.com'), false);
+  assert.equal(await isForbiddenLinkPreviewHost('cdn.example.org'), false);
+  assert.equal(await isForbiddenLinkPreviewHost('1.1.1.1'), false);
+  assert.equal(await isForbiddenLinkPreviewHost('8.8.8.8'), false);
 });
 
-test('isForbiddenLinkPreviewHost blocks empty/null/undefined', () => {
-  assert.equal(isForbiddenLinkPreviewHost(''), true);
-  assert.equal(isForbiddenLinkPreviewHost(null), true);
-  assert.equal(isForbiddenLinkPreviewHost(undefined), true);
-  assert.equal(isForbiddenLinkPreviewHost(), true);
+test('isForbiddenLinkPreviewHost blocks empty/null/undefined', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost(''), true);
+  assert.equal(await isForbiddenLinkPreviewHost(null), true);
+  assert.equal(await isForbiddenLinkPreviewHost(undefined), true);
+  assert.equal(await isForbiddenLinkPreviewHost(), true);
 });
 
-test('isForbiddenLinkPreviewHost with resolveDns=false skips DNS resolution', () => {
+test('isForbiddenLinkPreviewHost with resolveDns=false skips DNS resolution', async () => {
   // Direct IP blocks still work regardless of resolveDns
-  assert.equal(isForbiddenLinkPreviewHost('localhost', { resolveDns: false }), true);
-  assert.equal(isForbiddenLinkPreviewHost('192.168.1.1', { resolveDns: false }), true);
-  assert.equal(isForbiddenLinkPreviewHost('example.com', { resolveDns: false }), false);
+  assert.equal(await isForbiddenLinkPreviewHost('localhost', { resolveDns: false }), true);
+  assert.equal(await isForbiddenLinkPreviewHost('192.168.1.1', { resolveDns: false }), true);
+  assert.equal(await isForbiddenLinkPreviewHost('example.com', { resolveDns: false }), false);
 });
 
-test('resolveHostToIps handles IPv4 addresses', () => {
-  const ips = resolveHostToIps('1.1.1.1');
+test('resolveHostToIps handles IPv4 addresses', async () => {
+  const ips = await resolveHostToIps('1.1.1.1');
   assert.ok(Array.isArray(ips), 'should return an array');
   assert.ok(ips.includes('1.1.1.1'), 'should include the input IP');
 });
 
-test('resolveHostToIps handles IPv6 addresses', () => {
-  const ips = resolveHostToIps('::1');
+test('resolveHostToIps handles IPv6 addresses', async () => {
+  const ips = await resolveHostToIps('::1');
   assert.ok(Array.isArray(ips), 'should return an array for IPv6');
   assert.ok(ips.includes('::1') || ips.includes('[::1]'), 'should include the IPv6 address');
 });
 
-test('hostResolvesToPrivate detects 127.0.0.1 as private (DNS resolution may fail in containers)', () => {
-  const result = hostResolvesToPrivate('127.0.0.1');
+test('hostResolvesToPrivate detects 127.0.0.1 as private (DNS resolution may fail in containers)', async () => {
+  const result = await hostResolvesToPrivate('127.0.0.1');
   assert.equal(result, true, '127.0.0.1 should be detected as private IP');
 });
 
-test('hostResolvesToPrivate handles unresolvable hostnames gracefully', () => {
+test('hostResolvesToPrivate handles unresolvable hostnames gracefully', async () => {
   // Non-existent domain should not throw, should return false (can't confirm private)
-  const result = hostResolvesToPrivate('this-domain-definitely-does-not-exist-12345.com');
+  const result = await hostResolvesToPrivate('this-domain-definitely-does-not-exist-12345.com');
   assert.ok(typeof result === 'boolean', 'should return a boolean for unresolvable domains');
 });
 
 // ---- Acceptance criteria: IPv6 loopback and private cases ----
 
-test('IPv6 loopback ::1 is blocked', () => {
-  assert.equal(isForbiddenLinkPreviewHost('::1'), true);
+test('IPv6 loopback ::1 is blocked', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('::1'), true);
 });
 
-test('IPv6 link-local fe80::/10 range is blocked', () => {
-  assert.equal(isForbiddenLinkPreviewHost('fe80::1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('fe80::abcd'), true);
+test('IPv6 link-local fe80::/10 range is blocked', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('fe80::1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('fe80::abcd'), true);
 });
 
-test('IPv6 unique-local fc00::/7 range is blocked', () => {
-  assert.equal(isForbiddenLinkPreviewHost('fc00::1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('fd00::1'), true);
+test('IPv6 unique-local fc00::/7 range is blocked', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('fc00::1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('fd00::1'), true);
 });
 
-test('IPv6 unspecified :: is blocked', () => {
-  assert.equal(isForbiddenLinkPreviewHost('::'), true);
+test('IPv6 unspecified :: is blocked', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('::'), true);
 });
 
 // ---- Acceptance criteria: Direct private targets ----
 
-test('Direct private IPv4 targets are blocked', () => {
-  assert.equal(isForbiddenLinkPreviewHost('10.0.0.1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('192.168.1.1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('172.16.0.1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('127.0.0.1'), true);
-  assert.equal(isForbiddenLinkPreviewHost('169.254.169.254'), true); // cloud metadata
+test('Direct private IPv4 targets are blocked', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('10.0.0.1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('192.168.1.1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('172.16.0.1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('127.0.0.1'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('169.254.169.254'), true); // cloud metadata
 });
 
-test('Public IPv4 addresses are allowed', () => {
-  assert.equal(isForbiddenLinkPreviewHost('8.8.8.8'), false);
-  assert.equal(isForbiddenLinkPreviewHost('1.1.1.1'), false);
-  assert.equal(isForbiddenLinkPreviewHost('142.250.80.46'), false); // google.com
+test('Public IPv4 addresses are allowed', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('8.8.8.8'), false);
+  assert.equal(await isForbiddenLinkPreviewHost('1.1.1.1'), false);
+  assert.equal(await isForbiddenLinkPreviewHost('142.250.80.46'), false); // google.com
 });
 
 // ---- Integration-style: valid public redirect scenario ----
 
-test('Public hostnames are allowed for preview (simulates valid public redirect)', () => {
+test('Public hostnames are allowed for preview (simulates valid public redirect)', async () => {
   // These represent what would be validated at each hop of a public redirect chain
-  assert.equal(isForbiddenLinkPreviewHost('httpbin.org'), false);
-  assert.equal(isForbiddenLinkPreviewHost('redirect.example.com'), false);
-  assert.equal(isForbiddenLinkPreviewHost('example.com'), false);
+  assert.equal(await isForbiddenLinkPreviewHost('httpbin.org'), false);
+  assert.equal(await isForbiddenLinkPreviewHost('redirect.example.com'), false);
+  assert.equal(await isForbiddenLinkPreviewHost('example.com'), false);
 });
 
 // ---- Edge cases ----
 
-test('isForbiddenLinkPreviewHost handles case insensitivity', () => {
-  assert.equal(isForbiddenLinkPreviewHost('LOCALHOST'), true);
-  assert.equal(isForbiddenLinkPreviewHost('LoCaLhOsT'), true);
-  assert.equal(isForbiddenLinkPreviewHost('EXAMPLE.COM'), false);
+test('isForbiddenLinkPreviewHost handles case insensitivity', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('LOCALHOST'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('LoCaLhOsT'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('EXAMPLE.COM'), false);
 });
 
-test('isForbiddenLinkPreviewHost handles .localhost subdomains', () => {
-  assert.equal(isForbiddenLinkPreviewHost('foo.localhost'), true);
-  assert.equal(isForbiddenLinkPreviewHost('bar.foo.localhost'), true);
+test('isForbiddenLinkPreviewHost handles .localhost subdomains', async () => {
+  assert.equal(await isForbiddenLinkPreviewHost('foo.localhost'), true);
+  assert.equal(await isForbiddenLinkPreviewHost('bar.foo.localhost'), true);
+});
+
+
+test('DNS resolution blocks hostnames that resolve to private addresses', async () => {
+  const resolveHostToIps = async () => ['127.0.0.1'];
+  assert.equal(await isForbiddenLinkPreviewHost('private.example', { resolveHostToIps }), true);
+});
+
+test('DNS resolution allows hostnames that resolve only to public addresses', async () => {
+  const resolveHostToIps = async () => ['93.184.216.34'];
+  assert.equal(await isForbiddenLinkPreviewHost('public.example', { resolveHostToIps }), false);
 });


### PR DESCRIPTION
## Summary

- make link-preview SSRF hostname checks actually await DNS resolution
- resolve A/AAAA records with `dns.promises` and block hostnames resolving to private/link-local IPs
- await SSRF validation at the initial, redirect-hop, and final-response checks
- add resolver-injection regression tests for private/public DNS answers

## Validation

- `npm test`
- `npm run lint`

Refs #493
