### PR TITLE
fix: harden compose sample env and workflow publishing semantics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,15 @@
 # =============================================================================
 # Miso Chat - Environment Variables
 # =============================================================================
+# Copy this file to .env and customize for your environment.
+#
+# ── Docker Compose (local dev) ────────────────────────────────────────
+# When running via docker-compose.yml, the following defaults are safe
+# for local development but will intentionally fail in production:
+#   SESSION_SECRET=dev-secret-change-in-production
+#   OIDC_ENABLED=false
+#   LOCAL_USERS=admin:password123
+#   GATEWAY_URL=ws://host.docker.internal:18789
 
 # -------------------- Server Configuration --------------------
 
@@ -31,13 +40,14 @@ GATEWAY_URL=ws://openclaw.llm:18789
 # Web Push VAPID keys + contact subject (required when enabled)
 # Generate with: npx web-push generate-vapid-keys
 # PUSH_VAPID_PUBLIC_KEY=your-vapid-public-key
-# PUSH_VAPID_PRIVATE_KEY=your-vapid-private-key
+# PUSH_VAPID_PRIVATE_KEY=your-private-vapid-key
 # PUSH_VAPID_SUBJECT=mailto:admin@example.com
 
 # -------------------- Authentication --------------------
 
 # Session secret (REQUIRED - use a strong random string)
 # Generate with: openssl rand -base64 32
+# ⚠️  Never use the docker-compose dev default in production.
 SESSION_SECRET=change-this-to-a-random-secret-at-least-32-characters
 
 # Session cookie controls (optional)
@@ -54,6 +64,7 @@ OIDC_ENABLED=false
 
 # Local users (username:password, comma separated)
 # Only used when OIDC_ENABLED=false
+# ⚠️  Dev default — change for production.
 LOCAL_USERS=admin:password123
 
 # ----- Option 2: OIDC Authentication -----

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 ---
-name: Build
+name: CI Build & Publish
 on:
   push:
     branches:
@@ -33,6 +33,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
@@ -53,7 +54,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           tags: ghcr.io/${{ github.repository }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
 
       - name: Export digest
         run: |
@@ -87,6 +88,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 ---
-name: Build
+name: Release Build & Verify
 on:
   release:
     types:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,19 @@
 version: '3.8'
 
+# ── Sample Docker Compose ────────────────────────────────────────
+# This file is intended for local development. For production, copy
+# this template and override environment variables via a .env file
+# or your deployment platform.
+#
+# See .env.example for all available options.
+
 services:
   openclaw-chat:
     build: .
     ports:
       - "3000:3000"
-    environment:
-      - GATEWAY_URL=ws://host.docker.internal:18789
-      - SESSION_SECRET=dev-secret-change-in-production
-      - OIDC_ENABLED=false
-      - LOCAL_USERS=admin:password123
+    env_file:
+      - .env
     volumes:
       - .:/app
     restart: unless-stopped


### PR DESCRIPTION
## Problem

Three operational drift issues were identified in the sample compose config and release/build workflow metadata:

1. `docker-compose.yml` used hardcoded dev secrets (`SESSION_SECRET=dev-secret-change-in-production`, `LOCAL_USERS=admin:password123`) that are confusing as sample config and insecure for production.
2. Build/release workflows shared the same `name: Build`, making them indistinguishable in Actions history.
3. PR build path wrote untagged digests to GHCR unnecessarily.

## Changes

### Compose / Env Separation
- Added a **Docker Compose (local dev)** section at the top of `.env.example` that clearly lists safe dev defaults with security warnings about production use.
- Replaced hardcoded environment variables in `docker-compose.yml` with `env_file: .env` so values come from the user's own `.env` file.
- Added header comment clarifying this compose file is for local development only.

### Workflow Naming
- Renamed `build.yaml` workflow from **Build** → **CI Build & Publish**
- Renamed `release.yaml` workflow from **Build** → **Release Build & Verify**

### PR Registry Write Guard
- Added `if: github.event_name != 'pull_request'` to GHCR login steps in `build.yaml`.
- Changed build push to conditional: `push=${{ github.event_name != 'pull_request' }}` so PRs only build images without pushing to the registry.

## Acceptance Criteria Met
- ✅ Compose/sample env clearly separates dev-only and production-safe values
- ✅ Workflow names are unambiguous in Actions history
- ✅ PR validation avoids unnecessary registry writes

Fixes #498
