### PR TITLE
fix: restrict return_to and mobile auth handoff destinations (#495)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,12 @@ SESSION_SECRET=change-this-to-a-random-secret-at-least-32-characters
 # Optional: allow additional trusted origins for CSRF checks (comma-separated)
 # CSRF_TRUSTED_ORIGINS=https://miso-chat.yourdomain.com,https://app.yourdomain.com
 
+# Allowed origins for return_to redirects (comma-separated full origins)
+# Only used in OIDC web flows — same-origin relative paths are always allowed.
+# Without this, cross-origin https:// URLs in return_to are rejected (fallback to /).
+# Example: ALLOWED_RETURN_ORIGINS=https://sso.yourdomain.com,https://app.yourdomain.com
+# ALLOWED_RETURN_ORIGINS=
+
 # ----- Option 1: Local Authentication (default) -----
 # Set OIDC_ENABLED=false (or omit) to use local auth
 OIDC_ENABLED=false

--- a/server.js
+++ b/server.js
@@ -521,7 +521,15 @@ function getReturnTo(req, fallback = '/', mode = 'any') {
       : '');
 
   if (!raw) return fallback;
-  if (raw.startsWith('/')) return raw;
+  if (raw.startsWith('/')) {
+    // Normalize path segments (e.g., /foo/../bar → /bar) as defense-in-depth
+    try {
+      const normalized = new URL('http://x' + raw);
+      return normalized.pathname + normalized.search + normalized.hash || '/';
+    } catch {
+      return fallback;
+    }
+  }
 
   try {
     const parsed = new URL(raw);

--- a/server.js
+++ b/server.js
@@ -498,9 +498,22 @@ if (oidcEnabled) {
   ));
 }
 
-const allowedReturnToSchemes = new Set(['http:', 'https:', 'capacitor:', 'ionic:', 'misochat:']);
+const WEB_RETURN_TO_SCHEMES = new Set(['http:', 'https:']);
+const MOBILE_RETURN_TO_SCHEMES = new Set(['capacitor:', 'ionic:', 'misochat:']);
+const CROSS_ORIGIN_ALLOWLIST = new Set(
+  (process.env.ALLOWED_RETURN_ORIGINS || '')
+    .split(',')
+    .map((o) => {
+      try {
+        return new URL(o.trim()).origin;
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean)
+);
 
-function getReturnTo(req, fallback = '/') {
+function getReturnTo(req, fallback = '/', mode = 'any') {
   const raw = typeof req.body?.return_to === 'string' && req.body.return_to.trim()
     ? req.body.return_to.trim()
     : (typeof req.query?.return_to === 'string' && req.query.return_to.trim()
@@ -512,7 +525,29 @@ function getReturnTo(req, fallback = '/') {
 
   try {
     const parsed = new URL(raw);
-    if (!allowedReturnToSchemes.has(parsed.protocol)) return fallback;
+
+    if (mode === 'web') {
+      if (WEB_RETURN_TO_SCHEMES.has(parsed.protocol)) {
+        if (parsed.origin === `${req.protocol}://${req.get('host')}`) {
+          return parsed.pathname + parsed.search + parsed.hash;
+        }
+        if (CROSS_ORIGIN_ALLOWLIST.has(parsed.origin)) {
+          return parsed.toString();
+        }
+      }
+      return fallback;
+    }
+
+    if (mode === 'mobile') {
+      if (MOBILE_RETURN_TO_SCHEMES.has(parsed.protocol)) {
+        return parsed.toString();
+      }
+      return fallback;
+    }
+
+    // 'any' mode: allow any recognized scheme for backward compatibility
+    const allSchemes = new Set([...WEB_RETURN_TO_SCHEMES, ...MOBILE_RETURN_TO_SCHEMES]);
+    if (!allSchemes.has(parsed.protocol)) return fallback;
     return parsed.toString();
   } catch {
     return fallback;
@@ -582,7 +617,7 @@ const isAuthenticated = (req, res, next) => {
     });
   }
 
-  const returnTo = encodeURIComponent(getReturnTo(req, req.originalUrl || '/'));
+  const returnTo = encodeURIComponent(getReturnTo(req, req.originalUrl || '/', 'web'));
   return res.redirect(`/login?return_to=${returnTo}`);
 };
 
@@ -594,7 +629,7 @@ function getOidcLabel() {
 
 // Login
 app.get('/login', (req, res) => {
-  const returnTo = getReturnTo(req, '/');
+  const returnTo = getReturnTo(req, '/', 'web');
 
   if (authMode === 'none') {
     return res.redirect(returnTo);
@@ -622,11 +657,11 @@ app.get('/api/login-options', (req, res) => {
 
 app.post('/login', authLimiter, (req, res, next) => {
   if (!localAuthEnabled) {
-    const returnTo = encodeURIComponent(getReturnTo(req, '/'));
+    const returnTo = encodeURIComponent(getReturnTo(req, '/', 'web'));
     return res.redirect(`/login?error=local_disabled&return_to=${returnTo}`);
   }
 
-  const returnTo = getReturnTo(req, '/');
+  const returnTo = getReturnTo(req, '/', 'web');
   const failureReturnTo = encodeURIComponent(returnTo);
 
   return passport.authenticate('local', (err, user) => {
@@ -654,7 +689,7 @@ app.post('/login', authLimiter, (req, res, next) => {
 });
 app.get('/auth/oidc', (req, res, next) => {
   if (!oidcEnabled) return res.redirect('/login?error=oidc_disabled');
-  const returnTo = getReturnTo(req, '/');
+  const returnTo = getReturnTo(req, '/', 'web');
   const mobileRequested = req.query?.mobile === '1';
   const prompt = req.query?.prompt === 'login' ? 'login' : undefined;
   req.session.oidcReturnTo = returnTo;
@@ -671,7 +706,7 @@ app.get('/auth/oidc', (req, res, next) => {
 app.get('/auth/oidc/callback', (req, res, next) => {
   passport.authenticate('oidc', (err, user) => {
     if (err || !user) {
-      const returnTo = encodeURIComponent(getReturnTo(req, '/'));
+      const returnTo = encodeURIComponent(getReturnTo(req, '/', 'web'));
       return res.redirect(`/login?error=oidc_failed&return_to=${returnTo}`);
     }
 
@@ -680,14 +715,14 @@ app.get('/auth/oidc/callback', (req, res, next) => {
 
     return establishLoginSession(req, user, (loginErr) => {
       if (loginErr) {
-        const returnTo = encodeURIComponent(getReturnTo(req, '/'));
+        const returnTo = encodeURIComponent(getReturnTo(req, '/', 'web'));
         console.error('OIDC login session setup failed:', loginErr.message || loginErr);
         return res.redirect(`/login?error=oidc_failed&return_to=${returnTo}`);
       }
 
       return persistLoginSession(req, (saveErr) => {
         if (saveErr) {
-          const returnTo = encodeURIComponent(getReturnTo(req, '/'));
+          const returnTo = encodeURIComponent(getReturnTo(req, '/', 'web'));
           console.error('OIDC login session persist failed:', saveErr.message || saveErr);
           return res.redirect(`/login?error=oidc_failed&return_to=${returnTo}`);
         }
@@ -697,7 +732,7 @@ app.get('/auth/oidc/callback', (req, res, next) => {
         const mobileFlow = mobileFlowFromSession || (isMobileUa && !storedReturnTo);
 
         const safeReturnTo = storedReturnTo
-          ? getReturnTo({ query: { return_to: storedReturnTo } }, '/')
+          ? getReturnTo({ query: { return_to: storedReturnTo } }, '/', 'web')
           : (mobileFlow ? 'misochat://auth/callback' : '/');
 
         if (mobileFlow) {
@@ -736,7 +771,7 @@ app.post('/logout', (req, res) => {
 
 app.get('/auth/mobile-complete', (req, res) => {
   const token = typeof req.query?.token === 'string' ? req.query.token : '';
-  const returnTo = getReturnTo(req, '/');
+  const returnTo = getReturnTo(req, '/', 'mobile');
 
   if (!token) {
     return res.status(400).send('Missing mobile auth token');
@@ -1782,4 +1817,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { app, server, startServer };
+module.exports = { app, server, startServer, getReturnTo };

--- a/tests/return-to-security.test.js
+++ b/tests/return-to-security.test.js
@@ -103,14 +103,15 @@ test('invalid URLs fall back gracefully', () => {
   assert.equal(getReturnTo(req2, '/', 'mobile'), '/');
 });
 
-test('path traversal in relative paths stays relative and safe', () => {
+test('path traversal in relative paths is normalized by getReturnTo', () => {
   const req = makeReq('http', 'localhost:3000', { return_to: '/../etc/passwd' }, null);
-  assert.equal(getReturnTo(req, '/', 'web'), '/../etc/passwd');
+  assert.equal(getReturnTo(req, '/', 'web'), '/etc/passwd');
 
   const req2 = makeReq('http', 'localhost:3000', {}, { return_to: '/foo/../../bar' });
-  assert.equal(getReturnTo(req2, '/', 'web'), '/foo/../../bar');
+  assert.equal(getReturnTo(req2, '/', 'web'), '/bar');
 
   const req3 = makeReq('http', 'localhost:3000', { return_to: '/..%2F..%2Fetc/passwd' }, null);
+  // %2F is not decoded by URL class, so it stays as a literal segment
   assert.equal(getReturnTo(req3, '/', 'web'), '/..%2F..%2Fetc/passwd');
 });
 

--- a/tests/return-to-security.test.js
+++ b/tests/return-to-security.test.js
@@ -102,3 +102,22 @@ test('invalid URLs fall back gracefully', () => {
   const req2 = makeReq('http', 'localhost:3000', {}, { return_to: 'misochat://:invalid' });
   assert.equal(getReturnTo(req2, '/', 'mobile'), '/');
 });
+
+test('path traversal in relative paths stays relative and safe', () => {
+  const req = makeReq('http', 'localhost:3000', { return_to: '/../etc/passwd' }, null);
+  assert.equal(getReturnTo(req, '/', 'web'), '/../etc/passwd');
+
+  const req2 = makeReq('http', 'localhost:3000', {}, { return_to: '/foo/../../bar' });
+  assert.equal(getReturnTo(req2, '/', 'web'), '/foo/../../bar');
+
+  const req3 = makeReq('http', 'localhost:3000', { return_to: '/..%2F..%2Fetc/passwd' }, null);
+  assert.equal(getReturnTo(req3, '/', 'web'), '/..%2F..%2Fetc/passwd');
+});
+
+test('same-origin absolute URL with path traversal normalizes to relative path', () => {
+  const req = makeReq('http', 'localhost:3000', { return_to: 'http://localhost:3000/../dashboard' }, null);
+  assert.equal(getReturnTo(req, '/', 'web'), '/dashboard');
+
+  const req2 = makeReq('http', 'localhost:3000', {}, { return_to: 'http://localhost:3000/foo/../../bar' });
+  assert.equal(getReturnTo(req2, '/', 'web'), '/bar');
+});

--- a/tests/return-to-security.test.js
+++ b/tests/return-to-security.test.js
@@ -1,0 +1,104 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+process.env.NODE_ENV = 'test';
+process.env.SESSION_SECRET = 'test-session-secret-at-least-32-chars-long';
+process.env.AUTH_MODE = 'local';
+process.env.LOCAL_USERS = 'admin:password123';
+
+const { getReturnTo } = require('../server');
+
+function makeReq(protocol, host, body, query) {
+  return {
+    protocol: protocol || 'http',
+    get: (header) => {
+      if (header === 'host') return host || 'localhost:3000';
+      return '';
+    },
+    body: body || null,
+    query: query || null,
+  };
+}
+
+test('web mode rejects cross-origin http/https return_to', () => {
+  const req = makeReq('http', 'localhost:3000', { return_to: 'https://evil.example.com/phish' });
+  assert.equal(getReturnTo(req, '/', 'web'), '/');
+
+  const req2 = makeReq('http', 'localhost:3000', null, { return_to: 'https://phishing.evil.example.com/steal' });
+  assert.equal(getReturnTo(req2, '/', 'web'), '/');
+});
+
+test('web mode allows same-origin relative paths', () => {
+  const req = makeReq('http', 'localhost:3000', { return_to: '/dashboard' });
+  assert.equal(getReturnTo(req, '/', 'web'), '/dashboard');
+
+  const req2 = makeReq('http', 'localhost:3000', null, { return_to: '/chat?session=abc' });
+  assert.equal(getReturnTo(req2, '/', 'web'), '/chat?session=abc');
+
+  const req3 = makeReq('http', 'localhost:3000', {}, { return_to: '/sessions/123/messages' });
+  assert.equal(getReturnTo(req3, '/', 'web'), '/sessions/123/messages');
+});
+
+test('web mode allows same-origin absolute URLs (strips to path)', () => {
+  const req = makeReq('http', 'localhost:3000', { return_to: 'http://localhost:3000/dashboard' });
+  assert.equal(getReturnTo(req, '/', 'web'), '/dashboard');
+
+  const req2 = makeReq('https', 'localhost:3000', {}, { return_to: 'https://localhost:3000/chat?foo=bar' });
+  assert.equal(getReturnTo(req2, '/', 'web'), '/chat?foo=bar');
+});
+
+test('mobile mode allows mobile schemes', () => {
+  const req = makeReq('http', 'localhost:3000', { return_to: 'misochat://auth/callback' });
+  assert.equal(getReturnTo(req, '/', 'mobile'), 'misochat://auth/callback');
+
+  const req2 = makeReq('http', 'localhost:3000', {}, { return_to: 'capacitor://localhost/auth' });
+  assert.equal(getReturnTo(req2, '/', 'mobile'), 'capacitor://localhost/auth');
+
+  const req3 = makeReq('http', 'localhost:3000', { return_to: 'ionic://localhost/deep-link' }, null);
+  assert.equal(getReturnTo(req3, '/', 'mobile'), 'ionic://localhost/deep-link');
+});
+
+test('mobile mode rejects http/https', () => {
+  const req = makeReq('http', 'localhost:3000', { return_to: 'https://example.com' });
+  assert.equal(getReturnTo(req, '/', 'mobile'), '/');
+
+  const req2 = makeReq('http', 'localhost:3000', {}, { return_to: 'http://evil.com/phish' });
+  assert.equal(getReturnTo(req2, '/', 'mobile'), '/');
+});
+
+test('any mode accepts all schemes (backward compat)', () => {
+  const req = makeReq('http', 'localhost:3000', { return_to: 'https://example.com' });
+  assert.equal(getReturnTo(req, '/', 'any'), 'https://example.com/');
+
+  const req2 = makeReq('http', 'localhost:3000', {}, { return_to: 'misochat://auth/callback' });
+  assert.equal(getReturnTo(req2, '/', 'any'), 'misochat://auth/callback');
+
+  const req3 = makeReq('http', 'localhost:3000', { return_to: '/relative' }, null);
+  assert.equal(getReturnTo(req3, '/', 'any'), '/relative');
+});
+
+test('web mode rejects hostile return_to via query param', () => {
+  const req = makeReq('http', 'localhost:3000', null, { return_to: 'https://evil.example.com/steal' });
+  assert.equal(getReturnTo(req, '/', 'web'), '/');
+});
+
+test('web mode rejects hostile return_to via body param', () => {
+  const req = makeReq('http', 'localhost:3000', { return_to: 'https://evil.example.com/steal' }, null);
+  assert.equal(getReturnTo(req, '/', 'web'), '/');
+});
+
+test('empty and whitespace return_to falls back', () => {
+  const req = makeReq('http', 'localhost:3000', {}, {});
+  assert.equal(getReturnTo(req, '/fallback', 'web'), '/fallback');
+
+  const req2 = makeReq('http', 'localhost:3000', { return_to: '   ' }, null);
+  assert.equal(getReturnTo(req2, '/fallback', 'web'), '/fallback');
+});
+
+test('invalid URLs fall back gracefully', () => {
+  const req = makeReq('http', 'localhost:3000', { return_to: 'not a url at all' }, null);
+  assert.equal(getReturnTo(req, '/', 'web'), '/');
+
+  const req2 = makeReq('http', 'localhost:3000', {}, { return_to: 'misochat://:invalid' });
+  assert.equal(getReturnTo(req2, '/', 'mobile'), '/');
+});


### PR DESCRIPTION
## Summary

Fixes #495 (P1 security enhancement) by restricting `return_to` handling so web login returns are same-origin relative paths by default, cross-origin web returns require an explicit allowlist, and mobile schemes are only allowed for the mobile flow.

## Changes

### server.js
- Added `mode` parameter to `getReturnTo(req, fallback, mode)` — supports `web`, `mobile`, and `any` (backward compat)
- **Web mode**: Only allows same-origin relative paths by default. Cross-origin `http:`/`https:` URLs require the `ALLOWED_RETURN_ORIGINS` env var (comma-separated origins). Same-origin absolute URLs are stripped to their path component.
- **Mobile mode**: Only allows mobile URL schemes (`misochat:`, `capacitor:`, `ionic:`). Rejects `http:`/`https:` URLs.
- **Any mode** (default): Allows all recognized schemes for backward compatibility.
- Added `ALLOWED_RETURN_ORIGINS` env var parsing for cross-origin allowlist
- Updated all call sites to use `web` mode for web auth flows and `mobile` mode for the mobile auth handoff endpoint (`/auth/mobile-complete`)

### tests/return-to-security.test.js (new)
Regression tests covering:
- Hostile `return_to=https://evil.example/...` is rejected for web login
- Same-origin relative paths work for web login
- Same-origin absolute URLs are stripped to path in web mode
- Mobile schemes (`misochat://`, `capacitor://`, `ionic://`) work only in mobile mode
- HTTP/HTTPS rejected in mobile mode
- Empty/whitespace return_to falls back gracefully
- Invalid URLs fall back gracefully

## Acceptance criteria
- [x] Hostile `return_to=https://evil.example/...` is rejected or ignored for web login
- [x] Mobile schemes (`misochat:`, `capacitor:`, `ionic:`) remain supported only where intended
- [x] Regression tests cover hostile web return and allowed mobile return