### PR TITLE
fix: update gateway WebSocket protocol from v3 to v4

### DIFF
--- a/lib/gateway-ws.js
+++ b/lib/gateway-ws.js
@@ -187,8 +187,8 @@ class GatewayWsManager extends EventEmitter {
       id: this._connectId,
       method: 'connect',
       params: {
-        minProtocol: 3,
-        maxProtocol: 3,
+        minProtocol: 4,
+        maxProtocol: 4,
         client: {
           id: this.clientId,
           version: this.clientVersion,


### PR DESCRIPTION
### Root Cause

The OpenClaw gateway was upgraded to WebSocket **protocol v4**, but `lib/gateway-ws.js` was still sending `minProtocol: 3, maxProtocol: 3`. The gateway rejects v3 connections with:

```
PROTOCOL_MISMATCH: clientMinProtocol: 3, clientMaxProtocol: 3, expectedProtocol: 4
```

This causes the app to get stuck on **"Connecting to OpenClaw gateway…"** — no auth or data exchange ever starts.

### Fix

Updated protocol from `3` to `4` in the connect params.

### Verification

Tested protocol 4 against the production gateway with:
- `client.id: "webchat-ui"` + `Origin: https://miso-chat.jory.dev`
- Connection accepted through the auth challenge phase (device identity required)
- No more `PROTOCOL_MISMATCH`

### Note

The deployment is still on image `0.4.10` despite the helmrelease specifying `0.4.12` — you may need to trigger a rollout after merge so this fix actually lands on the pod.