### PR TITLE
docs: document mobileUpdateCache multi-instance limitation

### DIFF
--- a/server.js
+++ b/server.js
@@ -83,7 +83,10 @@ const MOBILE_UPDATE_REPO_OWNER = process.env.MOBILE_UPDATE_REPO_OWNER || "misosp
 const MOBILE_UPDATE_REPO_NAME = process.env.MOBILE_UPDATE_REPO_NAME || "miso-chat";
 const MOBILE_UPDATE_GITHUB_API_URL = "https://api.github.com";
 const MOBILE_UPDATE_CACHE_TTL_MS = Number(process.env.MOBILE_UPDATE_CACHE_TTL_MS || 300000); // 5 min default
-// In-memory cache: process-level only (not shared across multiple server instances behind LB)
+// In-memory cache: process-level only (not shared across multiple server instances behind LB).
+// Each instance maintains its own mobileUpdateCache and TTL independently, so multi-instance
+// deployments can serve stale manifests for up to MOBILE_UPDATE_CACHE_TTL_MS (default 5 min).
+// For multi-instance deployments, consider using a Redis-backed cache for this path.
 let mobileUpdateCache = null;
 let mobileUpdateCacheTime = 0;
 


### PR DESCRIPTION
Fixes #522

Enhanced the `mobileUpdateCache` comment in `server.js` to document:

- The cache is process-level only and not shared across multiple server instances behind a load balancer
- Each instance maintains its own cache and TTL independently, meaning stale manifests can be served for up to `MOBILE_UPDATE_CACHE_TTL_MS` (default 5 min) in multi-instance deployments
- Recommendation to use Redis-backed caching for multi-instance deployments