### PR TITLE
chore: release v0.4.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miso-chat",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miso-chat",
-      "version": "0.4.12",
+      "version": "0.4.13",
       "dependencies": {
         "@capacitor/android": "^8.1.0",
         "@capacitor/app": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miso-chat",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "private": true,
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
## Release v0.4.13

Contains:
- Release runbook docs (AGENTS.md)
- Dependency bump: `@capgo/capacitor-updater` 8.47.5 → 8.47.6
- CI: `actions/checkout` v6.0.2 → v6.0.3

## Validation
- lint: `node --check server.js` ✅
- test: 174/174 pass ✅
- audit: 0 vulnerabilities ✅