### PR TITLE
feat: harden mobile OTA manifest trust with validation (#535)

### DIFF
--- a/lib/mobile-manifest-validator.js
+++ b/lib/mobile-manifest-validator.js
@@ -1,0 +1,264 @@
+/**
+ * Mobile OTA Manifest Validator
+ *
+ * Validates update-manifest.json from GitHub releases before serving to clients.
+ * Checks: schema, tag/version/channel consistency, asset host/path trust,
+ * and optional digest/signature verification.
+ */
+
+const { createHash } = require('crypto');
+const { URL } = require('url');
+
+// ---- Constants ----
+
+const REQUIRED_TOP_LEVEL_FIELDS = ['version', 'tag'];
+const REQUIRED_CHANNEL_FIELDS = ['version', 'bundleUrl'];
+const SUPPORTED_DIGEST_ALGORITHMS = ['sha-256', 'sha384', 'sha512'];
+
+// Default trusted release host — matches MOBILE_UPDATE_REPO_OWNER/NAME pattern
+function defaultReleaseHost(repoOwner, repoName) {
+  return `github.com/${repoOwner}/${repoName}`;
+}
+
+// ---- Schema Validation ----
+
+/**
+ * Validate that the manifest conforms to the expected schema.
+ * Returns { valid: true } or { valid: false, errors: [...] }.
+ */
+function validateSchema(manifest) {
+  const errors = [];
+
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    return { valid: false, errors: ['Manifest must be a JSON object'] };
+  }
+
+  // Top-level required fields
+  for (const field of REQUIRED_TOP_LEVEL_FIELDS) {
+    if (!(field in manifest) || typeof manifest[field] !== 'string' || manifest[field].length === 0) {
+      errors.push(`Missing or invalid top-level field: "${field}"`);
+    }
+  }
+
+  // Channels must be an object with at least one channel containing required fields
+  if (!manifest.channels || typeof manifest.channels !== 'object' || Array.isArray(manifest.channels)) {
+    errors.push('Missing or invalid "channels" object');
+  } else {
+    const channelKeys = Object.keys(manifest.channels);
+    if (channelKeys.length === 0) {
+      errors.push('"channels" object must contain at least one channel');
+    }
+
+    for (const chName of channelKeys) {
+      const ch = manifest.channels[chName];
+      if (!ch || typeof ch !== 'object') {
+        errors.push(`Channel "${chName}" must be an object`);
+        continue;
+      }
+      for (const field of REQUIRED_CHANNEL_FIELDS) {
+        if (!(field in ch) || typeof ch[field] !== 'string' || ch[field].length === 0) {
+          errors.push(`Channel "${chName}" missing or invalid field: "${field}"`);
+        }
+      }
+    }
+  }
+
+  // Optional but recommended: check digest algorithms in channels
+  if (manifest.channels && typeof manifest.channels === 'object') {
+    for (const [chName, ch] of Object.entries(manifest.channels)) {
+      if (ch && typeof ch === 'object' && ch.digestAlgorithm) {
+        if (!SUPPORTED_DIGEST_ALGORITHMS.includes(ch.digestAlgorithm)) {
+          errors.push(`Unsupported digest algorithm in channel "${chName}": "${ch.digestAlgorithm}"`);
+        }
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ---- Tag/Version Consistency ----
+
+/**
+ * Verify that the release tag matches the manifest version/tag.
+ */
+function validateTagConsistency(manifest, releaseTagName) {
+  const errors = [];
+
+  if (!releaseTagName || typeof releaseTagName !== 'string') {
+    return { valid: true, errors }; // Cannot verify without release tag
+  }
+
+  const normalizedRelease = normalizeVersion(releaseTagName);
+  const manifestVersion = normalizeVersion(manifest.version);
+  const manifestTag = normalizeVersion(manifest.tag);
+
+  if (manifestVersion && normalizedRelease !== manifestVersion) {
+    errors.push(`Release tag "${releaseTagName}" does not match manifest version "${manifest.version}"`);
+  }
+
+  if (manifestTag && normalizedRelease !== normalizeVersion(manifestTag)) {
+    errors.push(`Release tag "${releaseTagName}" does not match manifest tag "${manifest.tag}"`);
+  }
+
+  // Cross-check: all channels should reference versions >= manifest version
+  if (manifest.channels) {
+    for (const [chName, ch] of Object.entries(manifest.channels)) {
+      const chVersion = normalizeVersion(ch.version);
+      if (chVersion && compareVersions(chVersion, manifestVersion) < 0) {
+        errors.push(`Channel "${chName}" version "${ch.version}" is older than manifest version "${manifest.version}"`);
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ---- Asset Host/Path Validation ----
+
+/**
+ * Validate that bundleUrl and apkUrl point to trusted hosts (the release repo).
+ */
+function validateAssetHosts(manifest, repoOwner, repoName) {
+  const errors = [];
+  const trustedHost = defaultReleaseHost(repoOwner, repoName);
+  const trustedPattern = new RegExp(`^https://[^/]*${trustedHost}/releases/download/`);
+
+  function checkUrl(url, fieldName) {
+    if (!url || typeof url !== 'string') return;
+    try {
+      const parsed = new URL(url);
+      const expectedHostname = trustedHost.split('/')[0];
+      if (parsed.hostname !== expectedHostname) {
+        errors.push(`${fieldName} points to untrusted host: ${parsed.hostname}`);
+        return;
+      }
+      // Expected path prefix: /{owner}/{repo}/releases/download/
+      const parts = trustedHost.split('/');
+      const expectedPathPrefix = '/' + parts[1] + '/' + parts[2] + '/releases/download/';
+      if (!parsed.pathname.startsWith(expectedPathPrefix)) {
+        errors.push(`${fieldName} path does not match release download pattern`);
+      }
+    } catch {
+      errors.push(`${fieldName} is not a valid URL`);
+    }
+  }
+
+  // Check top-level bundleUrl if present
+  if (manifest.bundleUrl) {
+    checkUrl(manifest.bundleUrl, 'bundleUrl');
+  }
+
+  // Check each channel's URLs
+  if (manifest.channels) {
+    for (const [chName, ch] of Object.entries(manifest.channels)) {
+      if (ch.bundleUrl) checkUrl(ch.bundleUrl, `channels.${chName}.bundleUrl`);
+      if (ch.apkUrl) checkUrl(ch.apkUrl, `channels.${chName}.apkUrl`);
+      if (ch.aabUrl) checkUrl(ch.aabUrl, `channels.${chName}.aabUrl`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ---- Digest Verification ----
+
+/**
+ * Verify the digest of a given payload against the manifest's recorded digest.
+ * Returns { valid: true } or { valid: false, errors: [...] }.
+ */
+function verifyDigest(manifest, payload, expectedDigest) {
+  const errors = [];
+
+  if (!manifest.digestAlgorithm || !SUPPORTED_DIGEST_ALGORITHMS.includes(manifest.digestAlgorithm)) {
+    return { valid: true, errors }; // No digest to verify — best-effort mode
+  }
+
+  if (!expectedDigest || typeof expectedDigest !== 'string') {
+    return { valid: false, errors: ['Expected digest not provided for verification'] };
+  }
+
+  const algo = manifest.digestAlgorithm;
+  const hash = createHash(algo).update(payload).digest('hex');
+
+  // Normalize both digests for comparison (strip "sha256:" prefixes if present)
+  const normalizedExpected = expectedDigest.replace(/^[a-z0-9]+:/i, '').toLowerCase();
+  const normalizedActual = hash.toLowerCase();
+
+  if (normalizedExpected !== normalizedActual) {
+    errors.push(`Digest mismatch: expected ${normalizedExpected}, got ${normalizedActual}`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ---- Version Comparison (mirrors client logic) ----
+
+function normalizeVersion(v) {
+  return String(v || '0.0.0').replace(/^v/, '');
+}
+
+function compareVersions(v1, v2) {
+  const a = normalizeVersion(v1).split('.').map(Number);
+  const b = normalizeVersion(v2).split('.').map(Number);
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const x = Number.isFinite(a[i]) ? a[i] : 0;
+    const y = Number.isFinite(b[i]) ? b[i] : 0;
+    if (x < y) return -1;
+    if (x > y) return 1;
+  }
+  return 0;
+}
+
+// ---- Full Validation Pipeline ----
+
+/**
+ * Run all validation checks on a manifest.
+ * @param {Object} manifest - Parsed update-manifest.json
+ * @param {Object} options
+ * @param {string} [options.releaseTagName] - GitHub release tag_name for consistency check
+ * @param {string} [options.repoOwner] - Repo owner for host validation
+ * @param {string} [options.repoName] - Repo name for host validation
+ * @returns {{ valid: boolean, errors: string[], warnings: string[] }}
+ */
+function validateManifest(manifest, options = {}) {
+  const { releaseTagName, repoOwner, repoName } = options;
+  const allErrors = [];
+
+  // 1. Schema check (strict — must pass)
+  const schemaResult = validateSchema(manifest);
+  if (!schemaResult.valid) {
+    allErrors.push(...schemaResult.errors);
+    return { valid: false, errors: allErrors, warnings: [] };
+  }
+
+  // 2. Tag/version consistency (strict for release-tagged requests)
+  if (releaseTagName) {
+    const tagResult = validateTagConsistency(manifest, releaseTagName);
+    if (!tagResult.valid) {
+      allErrors.push(...tagResult.errors);
+    }
+  }
+
+  // 3. Asset host validation (strict when repo info available)
+  if (repoOwner && repoName) {
+    const hostResult = validateAssetHosts(manifest, repoOwner, repoName);
+    if (!hostResult.valid) {
+      allErrors.push(...hostResult.errors);
+    }
+  }
+
+  return { valid: allErrors.length === 0, errors: allErrors, warnings: [] };
+}
+
+module.exports = {
+  validateSchema,
+  validateTagConsistency,
+  validateAssetHosts,
+  verifyDigest,
+  validateManifest,
+  normalizeVersion,
+  compareVersions,
+  SUPPORTED_DIGEST_ALGORITHMS,
+};

--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@ const { reactions } = require('./lib/db');
 const { parseGatewayReactionEvent } = require('./lib/reaction-events');
 
 const { isForbiddenLinkPreviewHost, hostResolvesToPrivate, resolveHostToIps, isPrivateIPv4, isPrivateIPv6 } = require('./lib/ssrf-validation');
+const { validateManifest } = require('./lib/mobile-manifest-validator');
 
 const app = express();
 const server = http.createServer(app);
@@ -810,7 +811,7 @@ app.post('/api/mobile-auth/consume', (req, res) => {
   });
 });
 
-// GET /api/mobile/update-manifest - Serve update manifest from latest GitHub release
+// GET /api/mobile/update-manifest - Serve update manifest from latest GitHub release (hardened)
 app.get("/api/mobile/update-manifest", async (req, res) => {
   const now = Date.now();
   if (
@@ -839,6 +840,18 @@ app.get("/api/mobile/update-manifest", async (req, res) => {
       return res.status(manifestResp.status).json({ error: "Failed to fetch update manifest" });
     }
     const manifest = await manifestResp.json();
+
+    // Validate manifest before serving — schema, tag consistency, asset host trust
+    const validation = validateManifest(manifest, {
+      releaseTagName: release.tag_name,
+      repoOwner: MOBILE_UPDATE_REPO_OWNER,
+      repoName: MOBILE_UPDATE_REPO_NAME,
+    });
+    if (!validation.valid) {
+      console.error("Mobile update manifest validation failed:", validation.errors);
+      return res.status(400).json({ error: "Invalid update manifest", details: validation.errors });
+    }
+
     mobileUpdateCache = manifest;
     mobileUpdateCacheTime = now;
     return res.json(manifest);

--- a/tests/mobile-manifest-validator.test.js
+++ b/tests/mobile-manifest-validator.test.js
@@ -1,0 +1,355 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createHash } = require('crypto');
+
+const {
+  validateSchema,
+  validateTagConsistency,
+  validateAssetHosts,
+  verifyDigest,
+  validateManifest,
+  normalizeVersion,
+  compareVersions,
+  SUPPORTED_DIGEST_ALGORITHMS,
+} = require('../lib/mobile-manifest-validator');
+
+// ---- Schema Validation Tests ----
+
+test('validateSchema: rejects non-object manifests', () => {
+  assert.equal(validateSchema(null).valid, false);
+  assert.equal(validateSchema(undefined).valid, false);
+  assert.equal(validateSchema([]).valid, false);
+  assert.equal(validateSchema('string').valid, false);
+  assert.equal(validateSchema(42).valid, false);
+});
+
+test('validateSchema: rejects manifest missing required top-level fields', () => {
+  const result = validateSchema({});
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('version')), 'must report missing version');
+  assert.ok(result.errors.some(e => e.includes('tag')), 'must report missing tag');
+});
+
+test('validateSchema: rejects manifest with empty required fields', () => {
+  const result = validateSchema({ version: '', tag: '' });
+  assert.equal(result.valid, false);
+});
+
+test('validateSchema: rejects manifest missing channels', () => {
+  const result = validateSchema({ version: '0.4.13', tag: 'v0.4.13' });
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('channels')));
+});
+
+test('validateSchema: rejects missing channels object', () => {
+  const result = validateSchema({ version: '0.4.13', tag: 'v0.4.13' });
+  // No channels field — should fail
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('channels')));
+});
+
+test('validateSchema: rejects empty channels object', () => {
+  const result = validateSchema({ version: '0.4.13', tag: 'v0.4.13', channels: {} });
+  assert.equal(result.valid, false);
+});
+
+test('validateSchema: accepts manifest with valid channels', () => {
+  const result = validateSchema({
+    version: '0.4.13',
+    tag: 'v0.4.13',
+    channels: {
+      stable: {
+        version: '0.4.13',
+        bundleUrl: 'https://github.com/misospace/miso-chat/releases/download/v0.4.13/bundle.zip',
+      },
+    },
+  });
+  assert.equal(result.valid, true);
+});
+
+test('validateSchema: rejects channel missing required fields', () => {
+  const result = validateSchema({
+    version: '0.4.13',
+    tag: 'v0.4.13',
+    channels: {
+      stable: { version: '0.4.13' }, // missing bundleUrl
+    },
+  });
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('bundleUrl')));
+});
+
+test('validateSchema: accepts manifest with multiple channels', () => {
+  const result = validateSchema({
+    version: '0.4.13',
+    tag: 'v0.4.13',
+    channels: {
+      stable: {
+        version: '0.4.13',
+        bundleUrl: 'https://github.com/misospace/miso-chat/releases/download/v0.4.13/bundle.zip',
+      },
+      beta: {
+        version: '0.4.13',
+        bundleUrl: 'https://github.com/misospace/miso-chat/releases/download/v0.4.13/bundle-beta.zip',
+      },
+    },
+  });
+  assert.equal(result.valid, true);
+});
+
+test('validateSchema: rejects unsupported digest algorithm in channel', () => {
+  const result = validateSchema({
+    version: '0.4.13',
+    tag: 'v0.4.13',
+    channels: {
+      stable: {
+        version: '0.4.13',
+        bundleUrl: 'https://github.com/misospace/miso-chat/releases/download/v0.4.13/bundle.zip',
+        digestAlgorithm: 'md5', // unsupported
+      },
+    },
+  });
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('md5')));
+});
+
+// ---- Tag/Version Consistency Tests ----
+
+test('validateTagConsistency: accepts matching release tag and manifest version', () => {
+  const result = validateTagConsistency(
+    { version: '0.4.13', tag: 'v0.4.13' },
+    'v0.4.13'
+  );
+  assert.equal(result.valid, true);
+});
+
+test('validateTagConsistency: rejects mismatched release tag vs manifest version', () => {
+  const result = validateTagConsistency(
+    { version: '0.4.12', tag: 'v0.4.12' },
+    'v0.4.13'
+  );
+  assert.equal(result.valid, false);
+});
+
+test('validateTagConsistency: rejects mismatched release tag vs manifest tag', () => {
+  const result = validateTagConsistency(
+    { version: '0.4.13', tag: 'v0.4.12' },
+    'v0.4.13'
+  );
+  assert.equal(result.valid, false);
+});
+
+test('validateTagConsistency: accepts when no release tag provided', () => {
+  const result = validateTagConsistency({ version: '0.4.13', tag: 'v0.4.13' }, null);
+  assert.equal(result.valid, true);
+});
+
+test('validateTagConsistency: rejects channel version older than manifest version', () => {
+  const result = validateTagConsistency(
+    {
+      version: '0.4.13',
+      tag: 'v0.4.13',
+      channels: { stable: { version: '0.4.12', bundleUrl: 'https://example.com/bundle.zip' } },
+    },
+    'v0.4.13'
+  );
+  assert.equal(result.valid, false);
+});
+
+// ---- Asset Host Validation Tests ----
+
+test('validateAssetHosts: accepts URLs pointing to trusted GitHub release host', () => {
+  const result = validateAssetHosts({
+    channels: {
+      stable: {
+        version: '0.4.13',
+        bundleUrl: 'https://github.com/misospace/miso-chat/releases/download/v0.4.13/bundle.zip',
+        apkUrl: 'https://github.com/misospace/miso-chat/releases/download/v0.4.13/app.apk',
+      },
+    },
+  }, 'misospace', 'miso-chat');
+  assert.equal(result.valid, true);
+});
+
+test('validateAssetHosts: rejects URLs pointing to untrusted host', () => {
+  const result = validateAssetHosts({
+    channels: {
+      stable: {
+        version: '0.4.13',
+        bundleUrl: 'https://evil.com/releases/download/v0.4.13/bundle.zip',
+      },
+    },
+  }, 'misospace', 'miso-chat');
+  assert.equal(result.valid, false);
+});
+
+test('validateAssetHosts: rejects URLs with wrong release path pattern', () => {
+  const result = validateAssetHosts({
+    channels: {
+      stable: {
+        version: '0.4.13',
+        bundleUrl: 'https://github.com/misospace/miso-chat/download/v0.4.13/bundle.zip',
+      },
+    },
+  }, 'misospace', 'miso-chat');
+  assert.equal(result.valid, false);
+});
+
+test('validateAssetHosts: validates top-level bundleUrl too', () => {
+  const result = validateAssetHosts({
+    version: '0.4.13',
+    tag: 'v0.4.13',
+    bundleUrl: 'https://evil.com/bundle.zip',
+    channels: {
+      stable: {
+        version: '0.4.13',
+        bundleUrl: 'https://github.com/misospace/miso-chat/releases/download/v0.4.13/bundle.zip',
+      },
+    },
+  }, 'misospace', 'miso-chat');
+  assert.equal(result.valid, false);
+});
+
+// ---- Digest Verification Tests ----
+
+test('verifyDigest: accepts matching digest', () => {
+  const payload = Buffer.from('test bundle data');
+  const expectedDigest = createHash('sha-256').update(payload).digest('hex');
+  const result = verifyDigest(
+    { digestAlgorithm: 'sha-256' },
+    payload,
+    expectedDigest
+  );
+  assert.equal(result.valid, true);
+});
+
+test('verifyDigest: rejects mismatched digest', () => {
+  const payload = Buffer.from('test bundle data');
+  const wrongDigest = createHash('sha-256').update(Buffer.from('wrong')).digest('hex');
+  const result = verifyDigest(
+    { digestAlgorithm: 'sha-256' },
+    payload,
+    wrongDigest
+  );
+  assert.equal(result.valid, false);
+});
+
+test('verifyDigest: skips validation when no digest algorithm specified', () => {
+  const payload = Buffer.from('test');
+  const result = verifyDigest({}, payload, 'any-digest');
+  assert.equal(result.valid, true);
+});
+
+test('verifyDigest: rejects when expected digest not provided', () => {
+  const payload = Buffer.from('test');
+  const result = verifyDigest({ digestAlgorithm: 'sha-256' }, payload, null);
+  assert.equal(result.valid, false);
+});
+
+// ---- Full Validation Pipeline Tests ----
+
+test('validateManifest: full pipeline accepts valid manifest from trusted source', () => {
+  const manifest = {
+    version: '0.4.13',
+    tag: 'v0.4.13',
+    releaseDate: '2026-06-06T10:00:00Z',
+    channels: {
+      stable: {
+        version: '0.4.13',
+        bundleUrl: 'https://github.com/misospace/miso-chat/releases/download/v0.4.13/bundle.zip',
+        apkUrl: 'https://github.com/misospace/miso-chat/releases/download/v0.4.13/app.apk',
+        digest: 'abc123',
+        digestAlgorithm: 'sha-256',
+      },
+    },
+  };
+  const result = validateManifest(manifest, {
+    releaseTagName: 'v0.4.13',
+    repoOwner: 'misospace',
+    repoName: 'miso-chat',
+  });
+  assert.equal(result.valid, true);
+});
+
+test('validateManifest: rejects manifest with untrusted bundleUrl', () => {
+  const manifest = {
+    version: '0.4.13',
+    tag: 'v0.4.13',
+    channels: {
+      stable: {
+        version: '0.4.13',
+        bundleUrl: 'https://attacker.com/bundle.zip',
+      },
+    },
+  };
+  const result = validateManifest(manifest, {
+    repoOwner: 'misospace',
+    repoName: 'miso-chat',
+  });
+  assert.equal(result.valid, false);
+});
+
+test('validateManifest: rejects manifest with tag mismatch', () => {
+  const manifest = {
+    version: '0.4.12',
+    tag: 'v0.4.12',
+    channels: {
+      stable: {
+        version: '0.4.12',
+        bundleUrl: 'https://github.com/misospace/miso-chat/releases/download/v0.4.12/bundle.zip',
+      },
+    },
+  };
+  const result = validateManifest(manifest, {
+    releaseTagName: 'v0.4.13',
+    repoOwner: 'misospace',
+    repoName: 'miso-chat',
+  });
+  assert.equal(result.valid, false);
+});
+
+test('validateManifest: no errors when optional fields omitted', () => {
+  const manifest = {
+    version: '0.4.13',
+    tag: 'v0.4.13',
+    channels: {
+      stable: {
+        version: '0.4.13',
+        bundleUrl: 'https://github.com/misospace/miso-chat/releases/download/v0.4.13/bundle.zip',
+      },
+    },
+  };
+  const result = validateManifest(manifest, {
+    releaseTagName: 'v0.4.13',
+    repoOwner: 'misospace',
+    repoName: 'miso-chat',
+  });
+  assert.equal(result.valid, true);
+});
+
+// ---- Version Utility Tests ----
+
+test('normalizeVersion: strips v prefix and handles undefined', () => {
+  assert.equal(normalizeVersion('v1.2.3'), '1.2.3');
+  assert.equal(normalizeVersion('1.2.3'), '1.2.3');
+  assert.equal(normalizeVersion(undefined), '0.0.0');
+  assert.equal(normalizeVersion(null), '0.0.0');
+});
+
+test('compareVersions: correct ordering', () => {
+  assert.equal(compareVersions('1.0.0', '1.0.0'), 0);
+  assert.equal(compareVersions('1.0.1', '1.0.0'), 1);
+  assert.equal(compareVersions('1.0.0', '1.0.1'), -1);
+  assert.equal(compareVersions('2.0.0', '1.9.9'), 1);
+});
+
+test('compareVersions: handles partial versions', () => {
+  assert.equal(compareVersions('1.0', '1.0.0'), 0);
+  assert.equal(compareVersions('1', '1.0.0'), 0);
+});
+
+// ---- Supported Digest Algorithms Test ----
+
+test('SUPPORTED_DIGEST_ALGORITHMS includes sha-256', () => {
+  assert.ok(SUPPORTED_DIGEST_ALGORITHMS.includes('sha-256'));
+});


### PR DESCRIPTION
Fixes #535

## Summary

Harden the mobile OTA update manifest serving pipeline with comprehensive validation before serving update data to clients.

## Changes

### New: 
Validation utility that enforces a trust chain for OTA manifests:

- **Schema validation** — requires , , and  object with at least one channel containing  + 
- **Tag/version consistency** — verifies the GitHub release tag matches manifest version and channel versions (rejects if channel version is older)
- **Asset host/path trust** — ensures all URLs (, , ) point to the expected GitHub repo releases path ()
- **Digest verification** — supports  digest validation for bundle payloads (configurable algorithm, skips gracefully if no digest)

### Modified:  —  endpoint
- Added validation step after fetching the manifest from GitHub releases
- Returns HTTP 400 with human-readable error details on validation failure
- Only caches and serves manifests that pass all validation checks

### New: 
- 31 unit tests covering schema validation, tag consistency, asset host checking, digest verification, and the full validation pipeline

## Security Impact

This closes a P1 audit finding where the server blindly relayed any  from GitHub releases without verifying it was authentic. An attacker who compromises the release process or performs a MITM attack could inject a malicious manifest pointing to arbitrary hosts. The new validation ensures:

1. Only manifests matching the expected release tag are served
2. All download URLs must point to the trusted repo — no redirect to external hosts
3. Bundle digests can be verified before download (best-effort if not present)