### PR TITLE
feat: add session/operation authorization boundary

### DIFF
--- a/lib/session-auth.js
+++ b/lib/session-auth.js
@@ -1,0 +1,126 @@
+/**
+ * Session/Operation Authorization Middleware
+ *
+ * Ensures authenticated users can only access sessions they own.
+ * Applied to routes that accept a sessionKey parameter.
+ *
+ * Ownership rules:
+ * - When auth is disabled (authMode === 'none'): all access allowed (no-op).
+ * - For local auth: the username from `req.user` must match the user portion
+ *   of the session key (e.g., `agent:<username>:<thread>` matches user `<username>`).
+ * - For OIDC: the user's email or preferred_username must appear in the session key.
+ * - If no ownership match is found, returns 403 Forbidden.
+ */
+
+/**
+ * Extract the expected owner from a session key.
+ * Handles formats like:
+ *   agent:<username>:<thread>
+ *   g-agent-<name>-<uuid>
+ *   <any-other-key> (returns null — no known owner pattern)
+ *
+ * @param {string} sessionKey
+ * @returns {string|null} - The inferred owner username, or null if unknown format.
+ */
+function extractSessionOwner(sessionKey) {
+  if (!sessionKey || typeof sessionKey !== 'string') return null;
+
+  // Format: agent:<username>:<rest>
+  const agentMatch = sessionKey.match(/^agent:([^:]+):/);
+  if (agentMatch && agentMatch[1]) {
+    return agentMatch[1];
+  }
+
+  // Format: g-agent-<name>-<uuid> or similar g-agent patterns
+  const gAgentMatch = sessionKey.match(/^(?:g-agent-|g_agent-)([^-_.]+)/i);
+  if (gAgentMatch && gAgentMatch[1]) {
+    return gAgentMatch[1].toLowerCase();
+  }
+
+  return null;
+}
+
+/**
+ * Check if the authenticated user owns (or has access to) a session.
+ *
+ * @param {object} req - Express request object with `user` populated by passport.
+ * @param {string} sessionKey - The session key being accessed.
+ * @param {string} authMode - One of 'none', 'local', 'oidc'.
+ * @returns {boolean} - true if the user is authorized to access this session.
+ */
+function checkSessionOwnership(req, sessionKey, authMode) {
+  // No auth mode: everything is accessible
+  if (authMode === 'none') return true;
+
+  // Must be authenticated
+  if (!req.user || !req.isAuthenticated?.()) return false;
+
+  const owner = extractSessionOwner(sessionKey);
+  if (!owner) {
+    // Unknown session key format — deny by default for safety.
+    // This catches any session key that doesn't follow the known patterns.
+    // In future, this could be relaxed if the Gateway provides explicit
+    // ownership metadata per session.
+    return false;
+  }
+
+  // Local auth: match username
+  if (authMode === 'local') {
+    const userIdentifier = String(req.user.username || '').toLowerCase().trim();
+    return userIdentifier === owner.toLowerCase();
+  }
+
+  // OIDC: match email or preferred_username against session key owner
+  if (authMode === 'oidc') {
+    const email = String(req.user.email || '').toLowerCase().trim();
+    const username = String(req.user.username || '').toLowerCase().trim();
+    return (
+      email.includes(owner.toLowerCase()) ||
+      username === owner.toLowerCase()
+    );
+  }
+
+  // Unknown auth mode: deny by default
+  return false;
+}
+
+/**
+ * Express middleware factory for session authorization.
+ *
+ * Usage:
+ *   app.get('/api/sessions/:key/history',
+ *     isAuthenticated,
+ *     requireSessionOwnership(authMode),
+ *     handler
+ *   );
+ *
+ * @param {string} authMode - The current auth mode from server.js.
+ * @returns {function} Express middleware function.
+ */
+function requireSessionOwnership(authMode) {
+  return function sessionOwnershipMiddleware(req, res, next) {
+    // Extract session key from URL params or query/body
+    let sessionKey = null;
+
+    if (req.params && req.params.key) {
+      sessionKey = String(req.params.key).trim();
+    } else if (req.query && typeof req.query.sessionKey === 'string') {
+      sessionKey = req.query.sessionKey.trim();
+    } else if (req.body && typeof req.body.sessionKey === 'string') {
+      sessionKey = req.body.sessionKey.trim();
+    }
+
+    // If no session key is provided, skip authorization (route doesn't target a specific session)
+    if (!sessionKey) return next();
+
+    if (!checkSessionOwnership(req, sessionKey, authMode)) {
+      return res.status(403).json({
+        error: 'Forbidden: you do not have access to this session',
+      });
+    }
+
+    return next();
+  };
+}
+
+module.exports = { checkSessionOwnership, requireSessionOwnership, extractSessionOwner };

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ require('dotenv').config();
 const { GatewayWsManager } = require('./lib/gateway-ws');
 const securityMiddleware = require('./security');
 const { reactions } = require('./lib/db');
+const { requireSessionOwnership } = require('./lib/session-auth');
 const { parseGatewayReactionEvent } = require('./lib/reaction-events');
 
 const { isForbiddenLinkPreviewHost, hostResolvesToPrivate, resolveHostToIps, isPrivateIPv4, isPrivateIPv6 } = require('./lib/ssrf-validation');
@@ -1229,7 +1230,7 @@ app.get('/api/sessions', isAuthenticated, async (req, res) => {
   }
 });
 
-app.get('/api/sessions/:key/history', isAuthenticated, async (req, res) => {
+app.get('/api/sessions/:key/history', isAuthenticated, requireSessionOwnership(authMode), async (req, res) => {
   try {
     const sessionKey = String(req.params.key || '').trim();
     if (!sessionKey) {
@@ -1281,7 +1282,7 @@ app.get('/api/sessions/:key/history', isAuthenticated, async (req, res) => {
   }
 });
 
-app.post('/api/sessions/:key/send', isAuthenticated, async (req, res) => {
+app.post('/api/sessions/:key/send', isAuthenticated, requireSessionOwnership(authMode), async (req, res) => {
   try {
     const sessionKey = String(req.params.key || '').trim();
     const text = String(req.body?.text || req.body?.message || '').trim();
@@ -1322,7 +1323,7 @@ app.post('/api/sessions/:key/send', isAuthenticated, async (req, res) => {
   }
 });
 
-app.post('/api/sessions/:key/send-stream', isAuthenticated, async (req, res) => {
+app.post('/api/sessions/:key/send-stream', isAuthenticated, requireSessionOwnership(authMode), async (req, res) => {
   try {
     const sessionKey = String(req.params.key || '').trim();
     const text = String(req.body?.text || req.body?.message || '').trim();
@@ -1470,7 +1471,7 @@ app.get('/api/link-preview', isAuthenticated, async (req, res) => {
 });
 
 // GET /api/openclaw-status - Return native OpenClaw session status card/details
-app.get('/api/openclaw-status', isAuthenticated, async (req, res) => {
+app.get('/api/openclaw-status', isAuthenticated, requireSessionOwnership(authMode), async (req, res) => {
   try {
     const sessionKey = typeof req.query.sessionKey === 'string' && req.query.sessionKey.trim()
       ? req.query.sessionKey.trim()
@@ -1496,7 +1497,7 @@ app.get('/api/openclaw-status', isAuthenticated, async (req, res) => {
 });
 
 // POST /api/openclaw-stop - Abort current OpenClaw chat run for a session
-app.post('/api/openclaw-stop', isAuthenticated, async (req, res) => {
+app.post('/api/openclaw-stop', isAuthenticated, requireSessionOwnership(authMode), async (req, res) => {
   try {
     const sessionKey = typeof req.body?.sessionKey === 'string' && req.body.sessionKey.trim()
       ? req.body.sessionKey.trim()
@@ -1621,7 +1622,7 @@ function inferAgentNameFromKey(sessionKey) {
 // ============ REACTION API ENDPOINTS ============
 
 // GET /api/reactions/:sessionKey - Get all reactions for a session (batch load)
-app.get('/api/reactions/:sessionKey', isAuthenticated, (req, res) => {
+app.get('/api/reactions/:sessionKey', isAuthenticated, requireSessionOwnership(authMode), (req, res) => {
   try {
     const { sessionKey } = req.params;
     const allReactions = reactions.getForSession(sessionKey);
@@ -1633,7 +1634,7 @@ app.get('/api/reactions/:sessionKey', isAuthenticated, (req, res) => {
 });
 
 // GET /api/messages/:messageId/reactions - Get reactions for a specific message
-app.get('/api/messages/:messageId/reactions', isAuthenticated, (req, res) => {
+app.get('/api/messages/:messageId/reactions', isAuthenticated, requireSessionOwnership(authMode), (req, res) => {
   try {
     const { messageId } = req.params;
     const sessionKey = typeof req.query?.sessionKey === 'string' ? req.query.sessionKey : null;
@@ -1646,7 +1647,7 @@ app.get('/api/messages/:messageId/reactions', isAuthenticated, (req, res) => {
 });
 
 // POST /api/messages/:messageId/reactions - Add or remove a reaction (toggle)
-app.post('/api/messages/:messageId/reactions', isAuthenticated, (req, res) => {
+app.post('/api/messages/:messageId/reactions', isAuthenticated, requireSessionOwnership(authMode), (req, res) => {
   try {
     const { messageId } = req.params;
     const { emoji, sessionKey } = req.body;

--- a/tests/session-auth.test.js
+++ b/tests/session-auth.test.js
@@ -1,0 +1,180 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { checkSessionOwnership, requireSessionOwnership, extractSessionOwner } = require('../lib/session-auth');
+
+// ===== extractSessionOwner tests =====
+
+test('extractSessionOwner parses agent:<username>:<thread> format', () => {
+  assert.equal(extractSessionOwner('agent:admin:main'), 'admin');
+  assert.equal(extractSessionOwner('agent:alice:thread-123'), 'alice');
+  assert.equal(extractSessionOwner('agent:bob:chat:gpt-4o-thread-abc'), 'bob');
+});
+
+test('extractSessionOwner parses g-agent-<name>-<uuid> format', () => {
+  assert.equal(extractSessionOwner('g-agent-chat-123e4567-e89b-12d3-a456-426614174000'), 'chat');
+  assert.equal(extractSessionOwner('g_agent-asistent-123e4567-e89b-12d3-a456-426614174000'), 'asistent');
+});
+
+test('extractSessionOwner returns null for unknown formats', () => {
+  assert.equal(extractSessionOwner('unknown-key'), null);
+  assert.equal(extractSessionOwner(''), null);
+  assert.equal(extractSessionOwner(null), null);
+  assert.equal(extractSessionOwner(undefined), null);
+  assert.equal(extractSessionOwner('agent:main:main'), 'main'); // edge case: single-part after agent:
+});
+
+// ===== checkSessionOwnership tests =====
+
+function makeUser(username, email) {
+  const user = { username };
+  if (email) user.email = email;
+  return user;
+}
+
+function makeRequest(user) {
+  return {
+    user,
+    isAuthenticated: () => true,
+  };
+}
+
+test('checkSessionOwnership allows access when authMode is none', () => {
+  const req = makeRequest(makeUser('anyone'));
+  assert.equal(checkSessionOwnership(req, 'agent:admin:main', 'none'), true);
+  assert.equal(checkSessionOwnership(req, 'unknown-key', 'none'), true);
+});
+
+test('checkSessionOwnership denies unauthenticated requests', () => {
+  const req = { user: null, isAuthenticated: () => false };
+  assert.equal(checkSessionOwnership(req, 'agent:admin:main', 'local'), false);
+});
+
+test('checkSessionOwnership allows matching local auth user', () => {
+  const req = makeRequest(makeUser('admin'));
+  assert.equal(checkSessionOwnership(req, 'agent:admin:main', 'local'), true);
+  assert.equal(checkSessionOwnership(req, 'agent:alice:thread-1', 'local'), false);
+});
+
+test('checkSessionOwnership allows matching OIDC user by username', () => {
+  const req = makeRequest(makeUser('alice', 'alice@example.com'));
+  assert.equal(checkSessionOwnership(req, 'agent:alice:main', 'oidc'), true);
+  assert.equal(checkSessionOwnership(req, 'agent:bob:main', 'oidc'), false);
+});
+
+test('checkSessionOwnership allows matching OIDC user by email substring', () => {
+  const req = makeRequest(makeUser('user123', 'alice@example.com'));
+  // email contains owner name
+  assert.equal(checkSessionOwnership(req, 'agent:alice:main', 'oidc'), true);
+});
+
+test('checkSessionOwnership denies unknown session key format', () => {
+  const req = makeRequest(makeUser('admin'));
+  assert.equal(checkSessionOwnership(req, 'unknown-session-key', 'local'), false);
+  assert.equal(checkSessionOwnership(req, 'unknown-session-key', 'oidc'), false);
+});
+
+// ===== requireSessionOwnership middleware tests =====
+
+function createReq(params, body, query) {
+  return {
+    params: params || {},
+    body: body || {},
+    query: query || {},
+    user: makeUser('admin'),
+    isAuthenticated: () => true,
+  };
+}
+
+function createResMock() {
+  const res = {
+    statusCode: 200,
+    payload: undefined,
+    headers: {},
+    setHeader(name, value) { this.headers[name] = value; },
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.payload = payload; return this; },
+  };
+  return res;
+}
+
+test('requireSessionOwnership middleware blocks unauthorized access', () => {
+  const mw = requireSessionOwnership('local');
+  const req = createReq({ key: 'agent:bob:main' });
+  const res = createResMock();
+  let nextCalled = false;
+
+  mw(req, res, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, false);
+  assert.equal(res.statusCode, 403);
+  assert.ok(res.payload.error.includes('Forbidden'));
+});
+
+test('requireSessionOwnership middleware allows authorized access', () => {
+  const mw = requireSessionOwnership('local');
+  const req = createReq({ key: 'agent:admin:main' });
+  const res = createResMock();
+  let nextCalled = false;
+
+  mw(req, res, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, true);
+});
+
+test('requireSessionOwnership middleware skips when no session key', () => {
+  const mw = requireSessionOwnership('local');
+  const req = createReq({});
+  const res = createResMock();
+  let nextCalled = false;
+
+  mw(req, res, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, true);
+});
+
+test('requireSessionOwnership middleware checks query sessionKey', () => {
+  const mw = requireSessionOwnership('local');
+  const req = createReq({}, {}, { sessionKey: 'agent:bob:main' });
+  const res = createResMock();
+  let nextCalled = false;
+
+  mw(req, res, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, false);
+});
+
+test('requireSessionOwnership middleware checks body sessionKey', () => {
+  const mw = requireSessionOwnership('local');
+  const req = createReq({}, { sessionKey: 'agent:bob:main' });
+  const res = createResMock();
+  let nextCalled = false;
+
+  mw(req, res, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, false);
+});
+
+test('requireSessionOwnership middleware allows OIDC user by email', () => {
+  const req = createReq({ key: 'agent:alice:main' });
+  req.user = makeUser('user123', 'alice@example.com');
+  const mw = requireSessionOwnership('oidc');
+  const res = createResMock();
+  let nextCalled = false;
+
+  mw(req, res, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, true);
+});
+
+test('requireSessionOwnership middleware denies OIDC user without match', () => {
+  const req = createReq({ key: 'agent:bob:main' });
+  req.user = makeUser('alice', 'alice@example.com');
+  const mw = requireSessionOwnership('oidc');
+  const res = createResMock();
+  let nextCalled = false;
+
+  mw(req, res, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, false);
+});


### PR DESCRIPTION
Fixes #534

Add session ownership verification middleware to all routes that accept a sessionKey parameter. This ensures authenticated users can only access sessions they own.

## Changes

### New file: `lib/session-auth.js`
- `extractSessionOwner(sessionKey)`: parses session keys to extract owner identity (handles `agent:<username>:<thread>` and `g-agent-<name>-<uuid>` formats)
- `checkSessionOwnership(req, sessionKey, authMode)`: verifies user has access to requested session
- `requireSessionOwnership(authMode)`: Express middleware factory

### Modified: `server.js`
Applied `requireSessionOwnership(authMode)` after `isAuthenticated` on 8 routes:
- GET /api/sessions/:key/history
- POST /api/sessions/:key/send
- POST /api/sessions/:key/send-stream
- GET /api/openclaw-status (when sessionKey query param provided)
- POST /api/openclaw-stop (when sessionKey body param provided)
- GET /api/reactions/:sessionKey
- GET /api/messages/:messageId/reactions (when sessionKey query param provided)
- POST /api/messages/:messageId/reactions (when sessionKey body param provided)

### New file: `tests/session-auth.test.js`
16 unit tests covering ownership extraction, middleware behavior, auth mode variants (none/local/oidc), and denial scenarios.

## Authorization Behavior

| Auth Mode | Ownership Check |
|-----------|----------------|
| `none` | All access allowed (no-op) |
| `local` | `req.user.username` must match session key owner |
| `oidc` | `req.user.email` or `req.user.username` must match session key owner |
| Unknown session format | Denied by default (fail-closed) |

## Security Impact

This addresses the P1 finding that authenticated users could access any session regardless of ownership. With this change, a user authenticated as `admin` cannot read history or send messages to sessions owned by other users.