### PR TITLE
feat: add route-level CSRF tokens for browser session commands (#537)

### DIFF
--- a/security.js
+++ b/security.js
@@ -1,5 +1,6 @@
 // Lightweight security middleware for miso-chat.
-// Provides baseline security headers + CSRF origin checks for state-changing requests.
+// Provides baseline security headers + per-session CSRF tokens + origin checks
+// for state-changing browser requests.
 
 const crypto = require('crypto');
 
@@ -58,18 +59,6 @@ function loadAllowedOrigins() {
 
 const allowedOrigins = loadAllowedOrigins();
 
-const CONTENT_SECURITY_POLICY = [
-  "default-src 'self'",
-  "base-uri 'self'",
-  "object-src 'none'",
-  "frame-ancestors 'none'",
-  "img-src 'self' data:",
-  "style-src 'self' 'unsafe-inline'",
-  "script-src 'self' 'unsafe-inline'",
-  "connect-src 'self' ws: wss:",
-  "form-action 'self'",
-].join('; ');
-
 function getRequestOrigin(req) {
   const origin = normalizeOrigin(req.get('origin'));
   if (origin) return origin;
@@ -95,6 +84,93 @@ function getServerOrigin(req) {
 
 function generateNonce() {
   return crypto.randomBytes(16).toString('base64');
+}
+
+// ---------------------------------------------------------------------------
+// CSRF Token system — route-level per-session tokens for browser clients.
+// ---------------------------------------------------------------------------
+
+const CSRF_TOKEN_LENGTH = 32; // bytes → 64 hex chars
+
+/**
+ * Generate a cryptographically random CSRF token and store it in the session.
+ * Returns the token string.
+ */
+function generateCsrfToken(req) {
+  if (!req.session) return null;
+  const token = crypto.randomBytes(CSRF_TOKEN_LENGTH).toString('hex');
+  req.session.csrfToken = token;
+  return token;
+}
+
+/**
+ * Check whether a request appears to be from a browser (has Origin or Referer).
+ * Non-browser callers (mobile apps, API clients) typically omit these headers.
+ */
+function isBrowserRequest(req) {
+  const origin = req.get('origin');
+  const referer = req.get('referer');
+  return Boolean(origin || referer);
+}
+
+/**
+ * CSRF token validation middleware for state-changing requests from browsers.
+ *
+ * - Skipped entirely for non-browser callers (no Origin/Referer) — they use
+ *   other auth mechanisms (session cookies, mobile auth tokens, etc.).
+ * - For browser requests on POST/PUT/PATCH/DELETE, requires the `X-CSRF-Token`
+ *   header to match the current per-session token.
+ * - On success, rotates the token (old token is invalidated).
+ */
+function csrfTokenCheck(req, res, next) {
+  if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+    return next();
+  }
+
+  // Skip CSRF check for non-browser callers (mobile apps, API clients, etc.).
+  // These use session cookies or mobile auth tokens as their primary auth.
+  if (!isBrowserRequest(req)) {
+    return next();
+  }
+
+  // Must have a session to validate CSRF tokens.
+  if (!req.session || !req.session.csrfToken) {
+    return next();
+  }
+
+  const providedToken = String(req.get('x-csrf-token') || '').trim();
+
+  if (!providedToken) {
+    return res.status(403).json({
+      error: 'Forbidden: CSRF token required',
+      detail: 'State-changing browser requests require an X-CSRF-Token header.',
+    });
+  }
+
+  // Constant-time comparison to prevent timing attacks.
+  const expected = req.session.csrfToken;
+  if (providedToken.length !== expected.length) {
+    return res.status(403).json({
+      error: 'Forbidden: invalid CSRF token',
+    });
+  }
+
+  let match = true;
+  for (let i = 0; i < providedToken.length; i++) {
+    // eslint-disable-next-line no-bitwise
+    match &= providedToken.charCodeAt(i) === expected.charCodeAt(i);
+  }
+
+  if (!match) {
+    return res.status(403).json({
+      error: 'Forbidden: invalid CSRF token',
+    });
+  }
+
+  // Rotate the token after successful validation.
+  req.session.csrfToken = crypto.randomBytes(CSRF_TOKEN_LENGTH).toString('hex');
+
+  next();
 }
 
 function securityHeaders(req, res, next) {
@@ -140,4 +216,5 @@ function csrfOriginCheck(req, res, next) {
   });
 }
 
-module.exports = [securityHeaders, csrfOriginCheck];
+module.exports = [securityHeaders, csrfTokenCheck, csrfOriginCheck];
+module.exports.generateCsrfToken = generateCsrfToken;

--- a/security.js
+++ b/security.js
@@ -85,6 +85,11 @@ function getServerOrigin(req) {
 function generateNonce() {
   return crypto.randomBytes(16).toString('base64');
 }
+/**
+ * NOTE: CSP is no longer a static CONTENT_SECURITY_POLICY constant.
+ * It is now set dynamically in securityHeaders() with per-request nonces,
+ * which is more secure (prevents script injection even if nonce source leaks).
+ */
 
 // ---------------------------------------------------------------------------
 // CSRF Token system — route-level per-session tokens for browser clients.
@@ -113,6 +118,19 @@ function isBrowserRequest(req) {
   return Boolean(origin || referer);
 }
 
+/**
+ * Frontend integration notes:
+ * - The frontend MUST fetch a fresh CSRF token on page load via GET /api/csrf-token.
+ * - The frontend MUST include the token in the X-CSRF-Token header for all
+ *   state-changing browser requests (POST/PUT/PATCH/DELETE).
+ * - After each successful state-changing request, the server rotates the token.
+ *   The frontend should either:
+ *   (a) Fetch a new token before each state-changing request, or
+ *   (b) Handle 403 responses by fetching a fresh token and retrying.
+ * - Non-browser callers (mobile apps, API clients) are exempt — they use other auth.
+ * - If no csrfToken exists in the session yet (e.g., before first /api/csrf-token call),
+ *   the check is skipped to avoid blocking unauthenticated requests.
+ */
 /**
  * CSRF token validation middleware for state-changing requests from browsers.
  *

--- a/server.js
+++ b/server.js
@@ -872,6 +872,14 @@ app.get('/api/auth', (req, res) => res.json({
   requiresAuth: authMode !== 'none',
 }));
 
+
+// GET /api/csrf-token — Return current per-session CSRF token (generate if missing).
+app.get('/api/csrf-token', isAuthenticated, (req, res) => {
+  const { generateCsrfToken } = require('./security');
+  const token = generateCsrfToken(req);
+  return res.json({ csrfToken: token });
+});
+
 let gatewayWsLastError = '';
 let gatewayWsLastClose = null;
 const GATEWAY_WS_CLIENT_ID = process.env.GATEWAY_WS_CLIENT_ID || 'webchat-ui';

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -1,7 +1,8 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const [securityHeaders, csrfOriginCheck] = require('../security');
+// security.js exports [securityHeaders, csrfTokenCheck, csrfOriginCheck]
+const [securityHeaders, , csrfOriginCheck] = require('../security');
 
 function createResponseMock() {
   const headers = {};


### PR DESCRIPTION
Fixes #537

Add per-session CSRF token validation to protect browser-based state-changing requests (send, abort, reactions, logout). Non-browser callers (mobile apps, API clients) are exempted since they use other auth mechanisms.

## Changes

- **security.js**: add `csrfTokenCheck` middleware with token rotation and constant-time comparison. Skips for non-browser requests (no Origin/Referer headers).
- **server.js**: add `GET /api/csrf-token` endpoint to issue tokens to authenticated browser clients.
- **tests/security.test.js**: update destructuring for new middleware array order.