### PR TITLE
feat: add SESSION_COOKIE_DOMAIN env var for subdomain isolation

### DIFF
--- a/server.js
+++ b/server.js
@@ -375,6 +375,16 @@ if (sessionCookieSameSite === 'none' && !sessionCookieSecure) {
   console.warn('⚠️ SESSION_COOKIE_SAMESITE=none without secure cookies may be rejected by modern browsers');
 }
 
+// Optional: set a domain for cross-subdomain session sharing.
+// Default is undefined (host-only cookie), which is the safest default.
+const sessionCookieDomain = process.env.SESSION_COOKIE_DOMAIN || undefined;
+if (sessionCookieDomain?.startsWith('.')) {
+  console.warn(
+    '⚠️ SESSION_COOKIE_DOMAIN is set to a wildcard domain. ' +
+      'Session cookies will be sent to all subdomains.',
+  );
+}
+
 const sessionConfig = {
   secret: sessionSecret,
   resave: false,
@@ -384,8 +394,11 @@ const sessionConfig = {
     httpOnly: true,
     // OIDC auth redirects are cross-site; Strict drops session cookie on callback and causes loops.
     // On mobile/WebView deployments that use an app origin, set SESSION_COOKIE_SAMESITE=none.
+    // For subdomain isolation, set SESSION_COOKIE_DOMAIN (e.g., ".example.com").
+    // When unset, cookies are host-only (default). Not recommended unless needed.
     sameSite: sessionCookieSameSite,
     maxAge: 24 * 60 * 60 * 1000,
+    domain: sessionCookieDomain,
   },
 };
 


### PR DESCRIPTION
Fixes #531

Add `SESSION_COOKIE_DOMAIN` environment variable support for deployments that need subdomain isolation.

## Changes

- Parse `SESSION_COOKIE_DOMAIN` env var (defaults to `undefined` for host-only cookies)
- Add warning log when wildcard domain is detected (e.g., `.example.com`)
- Apply `domain` property to the session cookie config
- Update inline comments to document the new env var alongside existing `SESSION_COOKIE_SECURE` and `SESSION_COOKIE_SAMESITE`

## Risk Mitigation

- Default is `undefined` (host-only) — the safest default
- Wildcard domains trigger a console warning
- Existing cookie behavior is unchanged when env var is not set