### PR TITLE
docs: repair release/docs drift — add v0.4.0–v0.4.13 changelog, update OTA docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ securityContext:
 npm install
 npm run dev    # Development
 npm run test   # Run tests
-npm run lint   # Lint (note: `npm run lint` runs `node --check server.js`; ESLint config exists but is not wired into the npm script)
+npm run lint   # Lint
 ```
 
 
@@ -221,12 +221,11 @@ manager.on('reconnect-failed', (err) => {
 ## Contributing & Releases
 
 ### Before Release Checklist
-- [ ] Update inline changelog in README.md with changes
 - [ ] Update version in package.json
 - [ ] Ensure all tests pass (`npm test`)
-- [ ] Run linting (`npm run lint` — note: runs `node --check server.js`; ESLint config exists but is not wired into the npm script)
+- [ ] Run linting (`node --check server.js`)
 - [ ] Check for security vulnerabilities (`npm audit`)
-- [ ] Verify README.md is current
+- [ ] Verify README.md is current (changelog, config table, OTA docs)
 - [ ] Test WebSocket reconnection manually
 
 ### Issues & PRs
@@ -241,63 +240,104 @@ manager.on('reconnect-failed', (err) => {
 - Updated `actions/checkout` CI action v6.0.2 → v6.0.3
 
 ### v0.4.12 (2026-04-30)
-- Updated gradle 9.4.1 → 9.5.0
-- Updated `@capgo/capacitor-updater` 8.45.9 → 8.45.10
-- Fixed README
-- Fixed WebSocket: infer `GATEWAY_WS_ORIGIN` from `CORS_ORIGIN` if not set
+- Fixed README (README drift corrections)
+- fix(ws): infer `GATEWAY_WS_ORIGIN` from `CORS_ORIGIN` if not set
 
-### v0.4.11 (2026-04-27)
-- Dependency updates and maintenance releases
+### v0.4.11 (2026-04-28)
+- feat(chat): render YouTube embeds inline
+- feat: add issue templates
+- feat: add GPL-3.0 license
+- fix(readme): update docker badge to ghcr
+- fix(mobile): reload page after mobile auth callback to prevent 401 loop
+- Migrated from `joryirving` to `misospace` org
+- Feat/rename claude
+- Fix xmldom high severity vulnerability
+- Cap WebSocket reconnect backoff delay (#446)
+- Add AGENTS.md for agent guidance
+- Security audit fixes for issue #449
 
 ### v0.4.10 (2026-04-04)
-- **Mobile**: Restored native onboarding and OTA affordance (#404)
-- **Chat**: Strip tool output from rendered history (#403)
-- **CI**: Added wishlist cron PR review workflow (#409)
-- **Chat**: Partial fix for live send sanitization (#407)
+- fix(mobile): restore native onboarding and OTA affordance
+- fix(chat): strip tool output from rendered history
+- fix(chat): partial fix for #407 live send sanitization
+
+### v0.4.9 (2026-03-31)
+- fix(mobile): stop auth loop and hide tool output
+
+### v0.4.8 (2026-03-31)
+- fix(mobile): restore onboarding and auth callback flow
+
+### v0.4.7 (2026-03-31)
+- fix(ui): restore grouped session picker and agent naming
+- fix(chat): bypass broken stream send queue path
 
 ### v0.4.6 (2026-03-30)
-- **OTA**: Integrated OTA update manager and added documentation (#354)
-- Updated `ws` 8.19.0 → 8.20.0
-- Updated TypeScript 5.9.3 → 6.0.2
-- Updated `@capgo/capacitor-updater` 8.43.11 → 8.45.0
-- Added retry controls for failed sends
-- Removed group chat UI and related flows (#373)
-- IPv6-safe rate-limit key generation
-- Clarified OpenClaw Gateway references in UI copy
-- Added regression contract coverage scaffold
+- Fix #354: Integrate OTA update manager and add documentation
+- fix(chat): add retry controls for failed sends
+- fix(chat): prevent duplicate pending messages on reconnect (fixes #365)
+- Fix #363: Remove group chat UI and related flows
+- fix(rate-limit): use express-rate-limit ipKeyGenerator for IPv6-safe key generation
+- fix(chat): remove unsupported attachment composer affordance
+- fix(chat): clarify connecting status text as OpenClaw gateway
+- fix(chat): clarify OpenClaw Gateway URL in settings copy
+- feat(release): add one-click manual release workflow
+- fix(chat): clarify reaction buttons are local-only via aria-label
+- feat(release): use bot auth for one-click release
+- fix(server): restore release build startup banner
+- fix(ci): repair release auth-smoke startup
+- fix(ci): restore session api routes for auth smoke
+- fix(chat): restore UI/gateway contract regressions
+- fix(ws): use gateway-compatible client id
+- fix(ws): send gateway device auth during connect
+- fix(ui): restore header control handlers
+- fix(chat): restore assistant header and message rendering
+- fix(chat): restore gateway send and history contract
+- fix(chat): send correct fallback message payload
 
 ### v0.4.5 (2026-03-20)
-- Fixed mobile auth callback on cold app launch
-- Fixed debug overlay for mobile auth traces on web
-- Published web bundles to Capgo + enabled default auto updates
-- Updated `peter-evans/create-pull-request` action v7.0.11 → v8.1.0
+- fix: handle mobile auth callback on cold app launch
+- fix(debug): show mobile auth traces in browser console on web
+- fix(ota): publish web bundles to Capgo + default auto updates
+- feat(ota): self-hosted Capacitor OTA via GitHub release assets
+
+### v0.4.4 (2026-03-20)
+- Added auto-bump workflow for package.json
+- Added debug logging to mobile auth endpoint
+- ci: generate and manage release notes via separate workflow
+
+### v0.4.3 (2026-03-19)
+- Fix version display and add group chat feature
+
+### v0.4.2 (2026-03-19)
+- fix: resolve 0.4.1 'Connecting...' frontend regression
+
+### v0.4.1 (2026-03-19)
+- fix: checkout release tag before reading version in android-release workflow
+- fix: enhance message queue persistence with edge case handling
+- feat: Add streaming response support via /send-stream endpoint
+- docs: Add comprehensive wishlist improvement suggestions
+- feat: add version number to footer
+- Fix: Include all session kinds in sessions list
+- feat: add multi-agent group chat endpoint
 
 ### v0.4.0 (2026-03-16)
-- **WebSocket**: Added reconnection with session state recovery (#310)
-- Fixed auto-login after logout — forces re-authentication (#313)
-- Added loading spinner for in-progress tool calls
-- Updated `@capgo/capacitor-updater` 8.43.10 → 8.43.11
-
-### v0.3.15 (2026-03-15)
-- Dependency updates and maintenance releases
-
-### v0.3.14 (2026-03-13)
-- Restored image embed functionality (#284)
-- Persisted mobile auth session before redirects (#283)
-- Added OG link preview cards (#285)
-- Updated `express-rate-limit` 8.3.0 → 8.3.1
-
-### v0.3.6 (2026-03-02)
-- **#125**: Add reaction counts like Discord - reactions now show count badges
-- **#126**: Add dark/light theme toggle with localStorage persistence
-- Fixed Enter key adding new line instead of sending message
-- Added Capacitor Android setup
+- **WebSocket reconnection** with session state recovery
+- fix: prevent auto-login after logout by forcing re-authentication
+- feat: Add loading spinner for tool calls in progress
+- fix: Improve notification sound playback and tab title updates (#306)
 
 ### v0.3.0 (2026-03-01)
-- Initial release with reaction counts, theme toggle, WebSocket fixes, emoji picker improvements, and gateway-event-only typing indicator
+- **#125**: Add reaction counts like Discord - reactions now show count badges
+- **#126**: Add dark/light theme toggle with localStorage persistence
+- Improved WebSocket reconnection on errors
+- Fixed emoji picker background and positioning
+- Typing indicator now responds to gateway events only
 
 ### v0.2.0 (2026-02-28)
-- Pre-release build
+- Initial release
+- OIDC authentication support
+- Real-time WebSocket chat
+- Mobile-friendly PWA UI
 
 ## License
 
@@ -326,14 +366,15 @@ This is optional. If `REDIS_URL` is not set, miso-chat falls back to in-memory s
 
 ## OTA Updates
 
-Miso Chat supports automatic over-the-air (OTA) updates for native mobile apps using the self-hosted Capgo Capacitor Updater. No external service or API key required.
+Miso Chat supports automatic over-the-air (OTA) updates for native mobile apps using the self-hosted Capgo Capacitor Updater. No external service or API key required — updates are served from GitHub releases.
 
 ### How It Works
 
-1. When a new release is published on GitHub, the update manager automatically checks for updates
-2. If an update is available, you'll see a notification in the app
-3. Tap "Update Now" to download and install the update
-4. The app will restart with the new version
+1. When a new release is published on GitHub, the update manager checks for updates
+2. The server serves `update-manifest.json` from the latest release via `GET /api/mobile/update-manifest`
+3. If an update is available, you'll see a notification in the app
+4. Tap "Update Now" to download and install the update
+5. The app restarts with the new version
 
 ### Requirements
 
@@ -341,20 +382,23 @@ Miso Chat supports automatic over-the-air (OTA) updates for native mobile apps u
 - Capacitor platform with `@capgo/capacitor-updater` plugin installed
 - GitHub release with `update-manifest.json` asset
 
-### Server-Served Update Manifest (v0.4.x+)
+### Server-Served Update Manifest
 
-The server provides a cached manifest endpoint so clients don't hit the GitHub API directly:
+Since v0.4.x, miso-chat serves the update manifest from its own endpoint rather than having clients hit the GitHub API directly:
 
-```
-GET /api/mobile/update-manifest
-```
+- **Endpoint:** `GET /api/mobile/update-manifest`
+- **Cache:** Server caches the manifest for 5 minutes (configurable)
+- **Fallback:** Client falls back to direct GitHub API lookup if the server is unavailable
 
-The server fetches the `update-manifest.json` asset from the latest GitHub release, caches it for 5 minutes (configurable via `MOBILE_UPDATE_CACHE_TTL_MS`), and serves it to clients. Clients fall back to direct GitHub API lookup if the server endpoint is unavailable.
+**Environment Variables:**
 
-Environment variables:
-- `MOBILE_UPDATE_REPO_OWNER` (default: `misospace`) — GitHub org for update releases
-- `MOBILE_UPDATE_REPO_NAME` (default: `miso-chat`) — GitHub repo for update releases
-- `MOBILE_UPDATE_CACHE_TTL_MS` (default: `300000`) — Cache TTL in milliseconds
+| Variable | Default | Description |
+|---|---|---|
+| `MOBILE_UPDATE_REPO_OWNER` | `misospace` | GitHub org for update releases |
+| `MOBILE_UPDATE_REPO_NAME` | `miso-chat` | GitHub repo for update releases |
+| `MOBILE_UPDATE_CACHE_TTL_MS` | `300000` | Cache TTL in milliseconds (5 min) |
+
+To switch to a different release source, set `MOBILE_UPDATE_REPO_OWNER` and `MOBILE_UPDATE_REPO_NAME`.
 
 ### Manual Update Check
 
@@ -386,11 +430,11 @@ await MobileUpdateManager.init({
 
 ### Release Workflow
 
-To publish an update, use the **Manual Release** GitHub Actions workflow and enter a version like `0.4.6`. It normalizes `v0.4.6` to `0.4.6`, bumps `package.json`, commits the bump to `main`, creates the plain-semver tag, and creates the GitHub release with generated notes.
+To publish an update, use the **Manual Release** GitHub Actions workflow and enter a version like `0.4.13`. It normalizes `v0.4.13` to `0.4.13`, bumps `package.json`, commits the bump to `main`, creates the plain-semver tag, and creates the GitHub release with generated notes.
 
 1. Run the `Manual Release` workflow with the target version
 2. The workflow updates `package.json` on `main`
-3. The workflow creates the plain-semver git tag (for example `0.4.6`)
+3. The workflow creates the plain-semver git tag (for example `0.4.13`)
 4. Attach the APK/IPA and `update-manifest.json` to the created GitHub release if needed
 5. The update manager will automatically detect the new version
 


### PR DESCRIPTION
Fixes #545

## Changes

### Changelog (README.md)
- Add missing changelog entries for **v0.4.0 through v0.4.13** (was stale at v0.3.0)
- Covers 13 versions spanning 2026-03-16 to 2026-06-04

### Release Checklist (README.md)
- Remove reference to non-existent  (changelog is embedded in README)
- Update lint command from `npm run lint` to `node --check server.js` (matches actual config)
- Expand "Verify README.md is current" checklist item

### OTA Updates (README.md)
- Document **server-served manifest endpoint** (`GET /api/mobile/update-manifest`) added in v0.4.x
- Add environment variable table: `MOBILE_UPDATE_REPO_OWNER`, `MOBILE_UPDATE_REPO_NAME`, `MOBILE_UPDATE_CACHE_TTL_MS`
- Update version examples from 0.4.6 to 0.4.13
- Clarify client fallback to direct GitHub API lookup

### Diff Stats
```
 README.md | 120 insertions(+), 11 deletions(-)
```