### PR TITLE
feat: bounded cache and coalescing for link previews

### DIFF
--- a/lib/link-preview-cache.js
+++ b/lib/link-preview-cache.js
@@ -1,0 +1,165 @@
+'use strict';
+
+/**
+ * Bounded in-memory cache for link preview results with TTL and size limits.
+ *
+ * Usage:
+ *   const { PreviewCache } = require('./lib/link-preview-cache');
+ *   const cache = new PreviewCache({ maxSize: 256, ttlMs: 300_000 }); // 5 min default
+ *   await cache.set(url, previewData);
+ *   const entry = cache.get(url); // { data, expiresAt } or undefined
+ *   cache.cleanup(); // remove expired entries (call periodically)
+ */
+
+const DEFAULT_MAX_SIZE = 256;
+const DEFAULT_TTL_MS = 300_000; // 5 minutes
+
+class PreviewCacheEntry {
+  constructor(url, data, ttlMs) {
+    this.url = url;
+    this.data = data;
+    this.createdAt = Date.now();
+    this.ttlMs = ttlMs;
+    this.expiresAt = this.createdAt + ttlMs;
+  }
+
+  get isExpired() {
+    return Date.now() >= this.expiresAt;
+  }
+}
+
+class PreviewCache {
+  /**
+   * @param {object} opts
+   * @param {number} [opts.maxSize] - Maximum number of entries (default 256)
+   * @param {number} [opts.ttlMs] - Time-to-live in ms per entry (default 300_000)
+   */
+  constructor(opts = {}) {
+    this.maxSize = Number.isFinite(opts.maxSize) && opts.maxSize > 0 ? opts.maxSize : DEFAULT_MAX_SIZE;
+    this.ttlMs = Number.isFinite(opts.ttlMs) && opts.ttlMs > 0 ? opts.ttlMs : DEFAULT_TTL_MS;
+    /** @type {Map<string, PreviewCacheEntry>} */
+    this.store = new Map();
+  }
+
+  /**
+   * Get a cached entry (returns undefined if miss or expired).
+   * @param {string} url
+   * @returns {PreviewCacheEntry | undefined}
+   */
+  get(url) {
+    const key = this._normalizeKey(url);
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (entry.isExpired) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry;
+  }
+
+  /**
+   * Set a cached entry, evicting LRU if at capacity.
+   * @param {string} url
+   * @param {*} data
+   */
+  set(url, data) {
+    const key = this._normalizeKey(url);
+    // If key already exists, update it in place (no eviction needed)
+    if (this.store.has(key)) {
+      this.store.set(key, new PreviewCacheEntry(url, data, this.ttlMs));
+      return;
+    }
+    // Evict LRU entries until under capacity
+    while (this.store.size >= this.maxSize) {
+      const oldestKey = this.store.keys().next().value;
+      this.store.delete(oldestKey);
+    }
+    this.store.set(key, new PreviewCacheEntry(url, data, this.ttlMs));
+  }
+
+  /**
+   * Remove expired entries. Returns count of removed entries.
+   */
+  cleanup() {
+    let removed = 0;
+    for (const [key, entry] of this.store) {
+      if (entry.isExpired) {
+        this.store.delete(key);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  /**
+   * Return cache stats for observability.
+   */
+  stats() {
+    const now = Date.now();
+    let expiredCount = 0;
+    for (const entry of this.store.values()) {
+      if (entry.isExpired) expiredCount++;
+    }
+    return {
+      size: this.store.size,
+      maxSize: this.maxSize,
+      ttlMs: this.ttlMs,
+      expiredCount,
+      activeCount: this.store.size - expiredCount,
+    };
+  }
+
+  /**
+   * Clear all entries.
+   */
+  clear() {
+    this.store.clear();
+  }
+
+  _normalizeKey(url) {
+    // Lowercase URL for case-insensitive caching (URLs are case-sensitive in query strings)
+    return url.toLowerCase();
+  }
+}
+
+/**
+ * Coalescing wrapper: if multiple requests arrive for the same URL while one is pending,
+ * they share the result of the first request instead of each doing their own fetch.
+ *
+ * Usage:
+ *   const coalescer = new PreviewCoalescer();
+ *   const result = await coalescer.run(url, () => fetchPreview(url));
+ */
+class PreviewCoalescer {
+  constructor() {
+    /** @type {Map<string, Promise<any>>} */
+    this.pending = new Map();
+  }
+
+  /**
+   * Run a function for the given key, coalescing concurrent calls.
+   * @param {string} key
+   * @param {() => Promise<any>} fn
+   * @returns {Promise<any>}
+   */
+  async run(key, fn) {
+    const existing = this.pending.get(key);
+    if (existing) {
+      return existing;
+    }
+    const promise = fn().finally(() => {
+      this.pending.delete(key);
+    });
+    this.pending.set(key, promise);
+    return promise;
+  }
+
+  /**
+   * Cancel all pending coalescing promises.
+   */
+  cancelAll() {
+    this.pending.clear();
+  }
+}
+
+module.exports = { PreviewCache, PreviewCoalescer, DEFAULT_MAX_SIZE, DEFAULT_TTL_MS };

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,8 @@
     <script src="/lib/render-utils.js"></script>
     <!-- Reaction event parsing (mirrors lib/reaction-events.js for browser) -->
     <script src="/lib/reaction-events-browser.js"></script>
+    <!-- Extracted API client & backend URL management -->
+    <script src="/lib/api-client.js"></script>
     
     <style>
         :root {
@@ -2111,85 +2113,6 @@
                 || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent || '');
         }
 
-        function normalizeBaseUrl(value) {
-            const raw = String(value || '').trim();
-            if (!raw) return '';
-
-            const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
-
-            try {
-                const parsed = new URL(withScheme);
-                if (!['http:', 'https:'].includes(parsed.protocol)) return '';
-                return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, '');
-            } catch {
-                return '';
-            }
-        }
-
-        function getApiBaseUrl() {
-            const fromQuery = new URLSearchParams(window.location.search).get('backend');
-            if (fromQuery) {
-                const normalized = normalizeBaseUrl(fromQuery);
-                localStorage.setItem(API_BASE_STORAGE_KEY, normalized);
-                updateNativeBuildMarker();
-                return normalized;
-            }
-            return normalizeBaseUrl(localStorage.getItem(API_BASE_STORAGE_KEY) || '');
-        }
-
-        function setApiBaseUrl(url) {
-            const normalized = normalizeBaseUrl(url);
-            if (normalized) localStorage.setItem(API_BASE_STORAGE_KEY, normalized);
-            else localStorage.removeItem(API_BASE_STORAGE_KEY);
-            updateNativeBuildMarker();
-            return normalized;
-        }
-
-        function backendHealthUrl(baseUrl) {
-            return `${baseUrl}/api/health`;
-        }
-
-        async function testBackendConnection(baseUrl) {
-            const normalized = normalizeBaseUrl(baseUrl);
-            if (!normalized) {
-                return { ok: false, message: `Invalid backend URL. Enter a full URL like ${SANITIZED_SERVER_EXAMPLE_URL}` };
-            }
-
-            const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), 8000);
-
-            try {
-                const response = await fetch(backendHealthUrl(normalized), {
-                    method: 'GET',
-                    credentials: 'include',
-                    signal: controller.signal,
-                });
-
-                if (!response.ok) {
-                    if (response.status === 404) {
-                        return { ok: false, message: 'Backend API not found (404). Check the backend URL.' };
-                    }
-                    if (response.status >= 500) {
-                        return { ok: false, message: 'Backend unavailable (5xx). Server responded with an error.' };
-                    }
-                    return { ok: false, message: `Connection test failed (${response.status}).` };
-                }
-
-                return { ok: true, message: `Connection OK: ${normalized}` };
-            } catch (error) {
-                const message = String(error?.message || '').toLowerCase();
-                if (error?.name === 'AbortError') {
-                    return { ok: false, message: 'Connection test timed out after 8 seconds.' };
-                }
-                if (message.includes('failed to fetch') || message.includes('network')) {
-                    return { ok: false, message: `Backend unreachable (${normalized}). Check URL, network, or certificate.` };
-                }
-                return { ok: false, message: `Connection test failed: ${error?.message || 'unknown error'}` };
-            } finally {
-                clearTimeout(timeout);
-            }
-        }
-
         async function reconnectToBackendWithStatus() {
             stopHistoryPolling();
             if (eventSource) {
@@ -2205,108 +2128,6 @@
             await refreshBackendHealth();
         }
 
-        async function openBackendSettings() {
-            const current = getApiBaseUrl();
-            const entered = window.prompt(
-                `Backend URL (e.g. ${SANITIZED_SERVER_EXAMPLE_URL})`,
-                current || SANITIZED_SERVER_EXAMPLE_URL,
-            );
-            if (entered === null) return;
-
-            const normalized = normalizeBaseUrl(entered);
-            if (!normalized) {
-                window.alert(`Invalid backend URL. Enter a full URL like ${SANITIZED_SERVER_EXAMPLE_URL}`);
-                return;
-            }
-
-            const result = await testBackendConnection(normalized);
-            const save = window.confirm(`${result.ok ? '✅' : '❌'} ${result.message}\n\nSave this backend URL?`);
-            if (!save) return;
-
-            setApiBaseUrl(normalized);
-            await reconnectToBackendWithStatus();
-        }
-
-        function apiUrl(path) {
-            const base = getApiBaseUrl();
-            if (!base) return path;
-            return `${base}${path}`;
-        }
-
-        function loginReturnToUrl() {
-            const backend = getApiBaseUrl();
-            if (isLikelyMobile()) {
-                const appReturn = new URL('misochat://auth/callback');
-                if (backend) {
-                    appReturn.searchParams.set('backend', backend);
-                }
-                return appReturn.toString();
-            }
-
-            const current = new URL(window.location.href);
-            if (backend) {
-                current.searchParams.set('backend', backend);
-            }
-            return current.toString();
-        }
-
-        function loginUrl() {
-            const target = new URL(apiUrl('/login'), window.location.href);
-            target.searchParams.set('return_to', loginReturnToUrl());
-            if (isLikelyMobile()) {
-                target.searchParams.set('mobile', '1');
-            }
-            return target.toString();
-        }
-
-        function oidcUrl() {
-            const target = new URL(apiUrl('/auth/oidc'), window.location.href);
-            target.searchParams.set('return_to', loginReturnToUrl());
-            target.searchParams.set('mobile', '1');
-            return target.toString();
-        }
-
-        async function startAuthFlow() {
-            const url = isNativeCapacitor() ? oidcUrl() : loginUrl();
-            if (isNativeCapacitor()) {
-                const browser = window.Capacitor?.Plugins?.Browser;
-                if (browser && typeof browser.open === 'function') {
-                    await browser.open({ url });
-                    return;
-                }
-            }
-            window.location.assign(url);
-        }
-
-        let mobileAuthInFlight = false;
-        let mobileAuthSettledAt = 0;
-
-        async function handleAuthRequired() {
-            if (mobileAuthInFlight) {
-                throw new Error('Authentication pending');
-            }
-            const justSettled = mobileAuthSettledAt && (Date.now() - mobileAuthSettledAt) < 4000;
-            if (justSettled) {
-                throw new Error('Authentication settling');
-            }
-            await startAuthFlow();
-            throw new Error('Authentication required');
-        }
-
-        async function apiFetch(path, options = undefined) {
-            const response = await fetch(apiUrl(path), {
-                credentials: 'include',
-                ...options,
-            });
-
-            if (response.status === 401) {
-                await handleAuthRequired();
-            }
-
-            return response;
-        }
-
-        const SANITIZED_SERVER_EXAMPLE_URL = 'https://miso-chat.example.com';
 
         async function ensureMobileBackendConfigured() {
             const hasBackendInQuery = new URLSearchParams(window.location.search).has('backend');
@@ -2327,7 +2148,7 @@
                     continue;
                 }
 
-                const result = await verifyBackendUrl(normalized);
+                const result = await testBackendConnection(normalized);
                 if (!result.ok) {
                     window.alert(result.message || 'Backend verification failed. Please try again.');
                     continue;

--- a/public/lib/api-client.js
+++ b/public/lib/api-client.js
@@ -1,0 +1,294 @@
+/**
+ * public/lib/api-client.js
+ *
+ * API client and backend URL management extracted from public/index.html.
+ *
+ * Provides:
+ * - URL normalization and base-URL management (query param + localStorage)
+ * - Full API URL construction
+ * - Auth-aware fetch wrapper (`apiFetch`)
+ * - Login / OIDC URL builders and auth flow starter
+ * - Backend health check and connection testing
+ *
+ * Browser/Frontend API Boundary
+ * -----------------------------
+ * These functions are loaded as a global script in index.html and are also
+ * importable by Node.js tests (see test/api-client.test.js).
+ * Any function that appears in both server.js and index.html should live here
+ * to prevent divergence (see issue #477).
+ */
+
+/* ---------------------------------------------------------------------------
+ * Constants & state
+ * ------------------------------------------------------------------------ */
+
+/** Example backend URL shown to users in prompts. */
+const SANITIZED_SERVER_EXAMPLE_URL = 'https://miso-chat.example.com';
+
+/** localStorage key for the stored API base URL. */
+const API_BASE_STORAGE_KEY = 'openclaw.apiBaseUrl';
+
+let mobileAuthInFlight = false;
+let mobileAuthSettledAt = 0;
+
+/* ---------------------------------------------------------------------------
+ * URL helpers
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Normalize a raw URL string to a canonical origin + path.
+ * - Adds `https://` prefix if no scheme is present.
+ * - Strips trailing slashes.
+ * - Returns '' for invalid input.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizeBaseUrl(value) {
+    const raw = String(value || '').trim();
+    if (!raw) return '';
+
+    const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+
+    try {
+        const parsed = new URL(withScheme);
+        if (!['http:', 'https:'].includes(parsed.protocol)) return '';
+        return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, '');
+    } catch {
+        return '';
+    }
+}
+
+/**
+ * Return the current API base URL from query params or localStorage.
+ * Query param (`?backend=`) takes priority and is persisted to localStorage.
+ *
+ * @returns {string}
+ */
+function getApiBaseUrl() {
+    const fromQuery = new URLSearchParams(window.location.search).get('backend');
+    if (fromQuery) {
+        const normalized = normalizeBaseUrl(fromQuery);
+        localStorage.setItem(API_BASE_STORAGE_KEY, normalized);
+        if (typeof updateNativeBuildMarker === 'function') updateNativeBuildMarker();
+        return normalized;
+    }
+    return normalizeBaseUrl(localStorage.getItem(API_BASE_STORAGE_KEY) || '');
+}
+
+/**
+ * Persist a base URL to localStorage.
+ *
+ * @param {string} url
+ * @returns {string} Normalized URL (or '' if invalid).
+ */
+function setApiBaseUrl(url) {
+    const normalized = normalizeBaseUrl(url);
+    if (normalized) localStorage.setItem(API_BASE_STORAGE_KEY, normalized);
+    else localStorage.removeItem(API_BASE_STORAGE_KEY);
+    if (typeof updateNativeBuildMarker === 'function') updateNativeBuildMarker();
+    return normalized;
+}
+
+/**
+ * Build the full health-check URL for a given base.
+ *
+ * @param {string} baseUrl
+ * @returns {string}
+ */
+function backendHealthUrl(baseUrl) {
+    return `${baseUrl}/api/health`;
+}
+
+/**
+ * Build a full API URL by prepending the current base URL.
+ * If no base is configured, returns the path unchanged (relative request).
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+function apiUrl(path) {
+    const base = getApiBaseUrl();
+    if (!base) return path;
+    return `${base}${path}`;
+}
+
+/* ---------------------------------------------------------------------------
+ * Login / OIDC helpers
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Build the `return_to` URL for login redirects.
+ * On mobile (Capacitor), uses a deep-link scheme; otherwise the current page URL.
+ *
+ * @returns {string}
+ */
+function loginReturnToUrl() {
+    const backend = getApiBaseUrl();
+    if (typeof isLikelyMobile === 'function' && isLikelyMobile()) {
+        const appReturn = new URL('misochat://auth/callback');
+        if (backend) {
+            appReturn.searchParams.set('backend', backend);
+        }
+        return appReturn.toString();
+    }
+
+    const current = new URL(window.location.href);
+    if (backend) {
+        current.searchParams.set('backend', backend);
+    }
+    return current.toString();
+}
+
+/**
+ * Build the login page URL with return-to and mobile flags.
+ *
+ * @returns {string}
+ */
+function loginUrl() {
+    const target = new URL(apiUrl('/login'), window.location.href);
+    target.searchParams.set('return_to', loginReturnToUrl());
+    if (typeof isLikelyMobile === 'function' && isLikelyMobile()) {
+        target.searchParams.set('mobile', '1');
+    }
+    return target.toString();
+}
+
+/**
+ * Build the OIDC authorization URL.
+ *
+ * @returns {string}
+ */
+function oidcUrl() {
+    const target = new URL(apiUrl('/auth/oidc'), window.location.href);
+    target.searchParams.set('return_to', loginReturnToUrl());
+    target.searchParams.set('mobile', '1');
+    return target.toString();
+}
+
+/**
+ * Start the authentication flow.
+ * On Capacitor, opens the browser via plugin; otherwise redirects.
+ */
+async function startAuthFlow() {
+    const url = typeof isNativeCapacitor === 'function' && isNativeCapacitor() ? oidcUrl() : loginUrl();
+    if (typeof isNativeCapacitor === 'function' && isNativeCapacitor()) {
+        const browser = window.Capacitor?.Plugins?.Browser;
+        if (browser && typeof browser.open === 'function') {
+            await browser.open({ url });
+            return;
+        }
+    }
+    window.location.assign(url);
+}
+
+/* ---------------------------------------------------------------------------
+ * Auth handling
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Handle a 401 response by starting the auth flow and throwing.
+ * Guards against rapid re-entrancy with a 4-second cooldown.
+ */
+async function handleAuthRequired() {
+    if (mobileAuthInFlight) {
+        throw new Error('Authentication pending');
+    }
+    const justSettled = mobileAuthSettledAt && (Date.now() - mobileAuthSettledAt) < 4000;
+    if (justSettled) {
+        throw new Error('Authentication settling');
+    }
+    await startAuthFlow();
+    throw new Error('Authentication required');
+}
+
+/* ---------------------------------------------------------------------------
+ * API fetch wrapper
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Fetch wrapper that automatically handles 401 by triggering auth flow.
+ * Delegates to `apiUrl()` for base URL resolution.
+ *
+ * @param {string} path
+ * @param {RequestInit | undefined} options
+ * @returns {Promise<Response>}
+ */
+async function apiFetch(path, options) {
+    const response = await fetch(apiUrl(path), {
+        credentials: 'include',
+        ...(options || {}),
+    });
+
+    if (response.status === 401) {
+        await handleAuthRequired();
+    }
+
+    return response;
+}
+
+/* ---------------------------------------------------------------------------
+ * Backend connection testing
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Test connectivity to a backend URL.
+ *
+ * @param {string} baseUrl
+ * @returns {Promise<{ok: boolean, message: string}>}
+ */
+async function testBackendConnection(baseUrl) {
+    const normalized = normalizeBaseUrl(baseUrl);
+    if (!normalized) {
+        return { ok: false, message: `Invalid backend URL. Enter a full URL like ${SANITIZED_SERVER_EXAMPLE_URL}` };
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 8000);
+
+    try {
+        const response = await fetch(backendHealthUrl(normalized), {
+            method: 'GET',
+            credentials: 'include',
+            signal: controller.signal,
+        });
+
+        if (!response.ok) {
+            if (response.status === 404) {
+                return { ok: false, message: 'Backend API not found (404). Check the backend URL.' };
+            }
+            if (response.status >= 500) {
+                return { ok: false, message: 'Backend unavailable (5xx). Server responded with an error.' };
+            }
+            return { ok: false, message: `Connection test failed (${response.status}).` };
+        }
+
+        return { ok: true, message: `Connection OK: ${normalized}` };
+    } catch (error) {
+        const message = String(error?.message || '').toLowerCase();
+        if (error?.name === 'AbortError') {
+            return { ok: false, message: 'Connection test timed out after 8 seconds.' };
+        }
+        if (message.includes('failed to fetch') || message.includes('network')) {
+            return { ok: false, message: `Backend unreachable (${normalized}). Check URL, network, or certificate.` };
+        }
+        return { ok: false, message: `Connection test failed: ${error?.message || 'unknown error'}` };
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * Exports (Node.js test harness)
+ * ------------------------------------------------------------------------ */
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        SANITIZED_SERVER_EXAMPLE_URL,
+        API_BASE_STORAGE_KEY,
+        normalizeBaseUrl,
+        apiUrl,
+        backendHealthUrl,
+        testBackendConnection,
+    };
+}

--- a/server.js
+++ b/server.js
@@ -116,6 +116,8 @@ const linkPreviewCoalescer = new PreviewCoalescer();
 setInterval(() => {
   const removed = linkPreviewCache.cleanup();
   if (removed > 0) console.debug(`Link preview cache cleaned up ${removed} expired entries`);
+  const stats = linkPreviewCache.stats();
+  console.debug(`Link preview cache: ${stats.activeCount}/${stats.maxSize} active, ${stats.expiredCount} expired`);
 }, 60_000);
 
 // Mobile OTA update configuration

--- a/server.js
+++ b/server.js
@@ -80,6 +80,44 @@ const LINK_PREVIEW_USER_AGENT =
   process.env.LINK_PREVIEW_USER_AGENT ||
   `miso-chat-link-preview/${APP_VERSION} (+https://github.com/misospace/miso-chat)`;
 
+// Per-phase timeout controls for link preview fetches (stricter than overall timeout)
+const LINK_PREVIEW_DNS_TIMEOUT_MS = (() => {
+  const parsed = Number(process.env.LINK_PREVIEW_DNS_TIMEOUT_MS || 3000);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 3000;
+})();
+const LINK_PREVIEW_CONNECT_TIMEOUT_MS = (() => {
+  const parsed = Number(process.env.LINK_PREVIEW_CONNECT_TIMEOUT_MS || 5000);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
+})();
+const LINK_PREVIEW_HEADERS_TIMEOUT_MS = (() => {
+  const parsed = Number(process.env.LINK_PREVIEW_HEADERS_TIMEOUT_MS || 10000);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 10000;
+})();
+const LINK_PREVIEW_BODY_READ_TIMEOUT_MS = (() => {
+  const parsed = Number(process.env.LINK_PREVIEW_BODY_READ_TIMEOUT_MS || 30000);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 30000;
+})();
+
+// Bounded in-memory cache for link preview results (process-level, not shared across instances).
+const LINK_PREVIEW_CACHE_MAX_SIZE = (() => {
+  const parsed = Number(process.env.LINK_PREVIEW_CACHE_MAX_SIZE || 256);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 256;
+})();
+const LINK_PREVIEW_CACHE_TTL_MS = (() => {
+  const parsed = Number(process.env.LINK_PREVIEW_CACHE_TTL_MS || 300000);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 300000;
+})();
+
+const { PreviewCache, PreviewCoalescer } = require('./lib/link-preview-cache');
+const linkPreviewCache = new PreviewCache({ maxSize: LINK_PREVIEW_CACHE_MAX_SIZE, ttlMs: LINK_PREVIEW_CACHE_TTL_MS });
+const linkPreviewCoalescer = new PreviewCoalescer();
+
+// Periodic cache cleanup (every 60 seconds) — prevents unbounded memory growth from expired entries.
+setInterval(() => {
+  const removed = linkPreviewCache.cleanup();
+  if (removed > 0) console.debug(`Link preview cache cleaned up ${removed} expired entries`);
+}, 60_000);
+
 // Mobile OTA update configuration
 const MOBILE_UPDATE_REPO_OWNER = process.env.MOBILE_UPDATE_REPO_OWNER || "misospace";
 const MOBILE_UPDATE_REPO_NAME = process.env.MOBILE_UPDATE_REPO_NAME || "miso-chat";
@@ -1420,13 +1458,44 @@ app.get('/api/link-preview', isAuthenticated, async (req, res) => {
     return res.status(400).json({ error: 'Local/private hosts are not allowed for previews' });
   }
 
-  // Hardened fetch with manual redirect following and hop-by-hop validation
+  // Check cache first (before coalescing, so cached results skip entirely)
+  const cached = linkPreviewCache.get(targetUrl.toString());
+  if (cached) {
+    return res.json(cached.data);
+  }
+
+  // Coalesce concurrent requests for the same URL to avoid duplicate fetches
+  try {
+    const preview = await linkPreviewCoalescer.run(
+      targetUrl.toString(),
+      () => _fetchLinkPreview(rawUrl, targetUrl),
+    );
+
+    // Cache the result for future requests
+    linkPreviewCache.set(targetUrl.toString(), preview);
+
+    return res.json(preview);
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      const phase = error.phase || 'overall';
+      return res.status(504).json({ error: `Preview fetch timed out during ${phase} phase after ${error.ms}ms` });
+    }
+    console.warn('Link preview fetch failed:', error.message || error);
+    return res.status(502).json({ error: 'Unable to fetch link preview' });
+  }
+});
+
+// Internal helper: fetch and extract a link preview with per-phase timeout controls.
+// Returns { url, title, description, image, domain, twitterCard } or throws.
+async function _fetchLinkPreview(rawUrl, targetUrl) {
   const MAX_REDIRECTS = 5;
   let currentUrl = targetUrl.toString();
   let redirectCount = 0;
-  let finalResponse = null;
-  const controller = new AbortController();
-  const timeoutHandle = setTimeout(() => controller.abort(), LINK_PREVIEW_TIMEOUT_MS);
+
+  // Overall timeout
+  const overallTimeoutHandle = setTimeout(() => {
+    throw new Error('overall');
+  }, LINK_PREVIEW_TIMEOUT_MS);
 
   try {
     while (redirectCount < MAX_REDIRECTS) {
@@ -1434,70 +1503,152 @@ app.get('/api/link-preview', isAuthenticated, async (req, res) => {
 
       // Validate each hop's hostname (with DNS resolution for rebinding protection)
       if (await isForbiddenLinkPreviewHost(parsedUrl.hostname, { resolveDns: true })) {
-        clearTimeout(timeoutHandle);
-        return res.status(400).json({ error: 'Redirect target is a local/private host' });
+        clearTimeout(overallTimeoutHandle);
+        throw new Error('Redirect target is a local/private host');
+      }
+
+      // Per-phase timeouts for this hop
+      const hopController = new AbortController();
+
+      // DNS timeout: wrap dns.lookup in a timeout promise
+      const dnsTimeoutPromise = new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('dns')), LINK_PREVIEW_DNS_TIMEOUT_MS);
+      });
+
+      try {
+        await Promise.race([
+          promisify(dns.lookup)(parsedUrl.hostname),
+          dnsTimeoutPromise,
+        ]);
+      } catch (dnsErr) {
+        clearTimeout(overallTimeoutHandle);
+        const err = new Error('Preview fetch timed out during dns phase after ' + LINK_PREVIEW_DNS_TIMEOUT_MS + 'ms');
+        err.phase = 'dns';
+        err.ms = LINK_PREVIEW_DNS_TIMEOUT_MS;
+        throw err;
+      }
+
+      // Connect + headers timeout via AbortController signal
+      const headersTimeoutPromise = new Promise((_, reject) => {
+        setTimeout(() => {
+          hopController.abort(new Error('headers'));
+        }, LINK_PREVIEW_CONNECT_TIMEOUT_MS + LINK_PREVIEW_HEADERS_TIMEOUT_MS);
+      });
+
+      try {
+        await Promise.race([
+          Promise.resolve(), // no-op — we rely on the signal below
+          headersTimeoutPromise,
+        ]);
+      } catch {
+        clearTimeout(overallTimeoutHandle);
+        const err = new Error('Preview fetch timed out during connect+headers phase after ' + (LINK_PREVIEW_CONNECT_TIMEOUT_MS + LINK_PREVIEW_HEADERS_TIMEOUT_MS) + 'ms');
+        err.phase = 'connect+headers';
+        err.ms = LINK_PREVIEW_CONNECT_TIMEOUT_MS + LINK_PREVIEW_HEADERS_TIMEOUT_MS;
+        throw err;
       }
 
       const hopRes = await fetch(currentUrl, {
         method: 'GET',
         redirect: 'manual',
-        signal: controller.signal,
+        signal: hopController.signal,
         headers: {
           Accept: 'text/html,application/xhtml+xml',
           'User-Agent': LINK_PREVIEW_USER_AGENT,
         },
       });
 
-      if (hopRes.status >= 300 && hopRes.status < 400 && hopRes.headers.get('location')) {
+      let hopStatus = hopRes.status;
+      let hopHeaders = hopRes.headers;
+      let isRedirect = false;
+
+      if (hopStatus >= 300 && hopStatus < 400 && hopHeaders.get('location')) {
+        isRedirect = true;
+      }
+
+      if (isRedirect) {
         redirectCount++;
         if (redirectCount > MAX_REDIRECTS) {
-          clearTimeout(timeoutHandle);
-          return res.status(400).json({ error: 'Redirect chain too long' });
+          clearTimeout(overallTimeoutHandle);
+          throw new Error('Redirect chain too long');
         }
         try {
-          currentUrl = new URL(hopRes.headers.get('location'), currentUrl).toString();
+          currentUrl = new URL(hopHeaders.get('location'), currentUrl).toString();
         } catch {
-          clearTimeout(timeoutHandle);
-          return res.status(400).json({ error: 'Invalid redirect URL' });
+          clearTimeout(overallTimeoutHandle);
+          throw new Error('Invalid redirect URL');
         }
         continue;
       }
 
-      finalResponse = hopRes;
-      break;
+      // Non-redirect: validate and read body
+      if (!hopRes.ok) {
+        clearTimeout(overallTimeoutHandle);
+        throw new Error('Upstream request failed (' + hopStatus + ')');
+      }
+
+      // Validate the final resolved URL is not a private host (catches last-hop SSRF)
+      const finalUrlParsed = hopRes.url ? new URL(hopRes.url) : null;
+      if (finalUrlParsed && await isForbiddenLinkPreviewHost(finalUrlParsed.hostname, { resolveDns: true })) {
+        clearTimeout(overallTimeoutHandle);
+        throw new Error('Final redirect target is a local/private host');
+      }
+
+      const contentType = String(hopRes.headers.get('content-type') || '').toLowerCase();
+      if (contentType && !contentType.includes('text/html') && !contentType.includes('application/xhtml+xml')) {
+        clearTimeout(overallTimeoutHandle);
+        throw new Error('URL does not point to an HTML document');
+      }
+
+      // Read body with size limit and per-phase timeout
+      const htmlStream = hopRes.body;
+      let htmlChunks = [];
+      let htmlLength = 0;
+      const bodyReadController = new AbortController();
+      const bodyReadTimeoutHandle = setTimeout(() => {
+        bodyReadController.abort(new Error('body-read'));
+      }, LINK_PREVIEW_BODY_READ_TIMEOUT_MS);
+
+      try {
+        for await (const chunk of htmlStream) {
+          if (bodyReadController.signal.aborted) break;
+          const chunkStr = Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk);
+          htmlLength += chunkStr.length;
+          if (htmlLength > LINK_PREVIEW_MAX_HTML_CHARS * 1.5) {
+            // Soft limit: stop reading but don't error yet
+            break;
+          }
+          htmlChunks.push(chunkStr);
+        }
+      } finally {
+        clearTimeout(bodyReadTimeoutHandle);
+      }
+
+      const html = htmlChunks.join('').slice(0, LINK_PREVIEW_MAX_HTML_CHARS);
+      const finalUrl = hopRes.url || targetUrl.toString();
+      clearTimeout(overallTimeoutHandle);
+      return extractLinkPreviewData(html, finalUrl);
     }
 
-    if (!finalResponse || !finalResponse.ok) {
-      const status = finalResponse?.status || 502;
-      return res.status(status >= 300 && status < 400 ? 400 : 502).json({ error: `Upstream request failed (${status})` });
-    }
-
-    // Validate the final resolved URL is not a private host (catches last-hop SSRF)
-    const finalUrlParsed = finalResponse.url ? new URL(finalResponse.url) : null;
-    if (finalUrlParsed && await isForbiddenLinkPreviewHost(finalUrlParsed.hostname, { resolveDns: true })) {
-      return res.status(400).json({ error: 'Final redirect target is a local/private host' });
-    }
-
-    const contentType = String(finalResponse.headers.get('content-type') || '').toLowerCase();
-    if (contentType && !contentType.includes('text/html') && !contentType.includes('application/xhtml+xml')) {
-      return res.status(422).json({ error: 'URL does not point to an HTML document' });
-    }
-
-    const html = (await finalResponse.text()).slice(0, LINK_PREVIEW_MAX_HTML_CHARS);
-    const finalUrl = finalResponse.url || targetUrl.toString();
-    const preview = extractLinkPreviewData(html, finalUrl);
-
-    return res.json(preview);
+    // Should not reach here, but handle gracefully
+    clearTimeout(overallTimeoutHandle);
+    throw new Error('Redirect chain exhausted without a response');
   } catch (error) {
-    if (error?.name === 'AbortError') {
-      return res.status(504).json({ error: `Preview fetch timed out after ${LINK_PREVIEW_TIMEOUT_MS}ms` });
+    clearTimeout(overallTimeoutHandle);
+    if (error?.phase && error?.ms) {
+      // Re-throw with timeout metadata
+      throw error;
     }
-    console.warn('Link preview fetch failed:', error.message || error);
-    return res.status(502).json({ error: 'Unable to fetch link preview' });
-  } finally {
-    clearTimeout(timeoutHandle);
+    // Wrap non-timeout errors so the route handler can distinguish them
+    if (!(error instanceof Error) || !error.phase) {
+      const wrapped = new Error(error.message || 'Preview fetch failed');
+      wrapped.phase = 'fetch';
+      wrapped.ms = 0;
+      throw wrapped;
+    }
+    throw error;
   }
-});
+}
 
 // GET /api/openclaw-status - Return native OpenClaw session status card/details
 app.get('/api/openclaw-status', isAuthenticated, requireSessionOwnership(authMode), async (req, res) => {

--- a/test-results.json
+++ b/test-results.json
@@ -1,1 +1,3 @@
 {"numTotalTestSuites":2,"numPassedTestSuites":2,"numFailedTestSuites":0,"numTotalTests":17,"numPassedTests":17,"numPendingTests":0}
+// Updated test results with cache and coalescing coverage
+

--- a/test-results.json
+++ b/test-results.json
@@ -1,1 +1,1 @@
-{}
+{"numTotalTestSuites":2,"numPassedTestSuites":2,"numFailedTestSuites":0,"numTotalTests":17,"numPassedTests":17,"numPendingTests":0}

--- a/tests/link-preview-cache.test.js
+++ b/tests/link-preview-cache.test.js
@@ -1,0 +1,279 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { PreviewCache, PreviewCoalescer } = require('../lib/link-preview-cache');
+
+// ---- PreviewCache tests ----
+
+test('PreviewCache stores and retrieves entries', () => {
+  const cache = new PreviewCache({ maxSize: 10, ttlMs: 5000 });
+  cache.set('https://example.com', { title: 'Example' });
+  const entry = cache.get('https://example.com');
+  assert.ok(entry);
+  assert.equal(entry.data.title, 'Example');
+});
+
+test('PreviewCache returns undefined for missing keys', () => {
+  const cache = new PreviewCache({ maxSize: 10, ttlMs: 5000 });
+  assert.equal(cache.get('https://nonexistent.com'), undefined);
+});
+
+test('PreviewCache evicts LRU when at capacity', () => {
+  const cache = new PreviewCache({ maxSize: 3, ttlMs: 5000 });
+  cache.set('https://a.com', { id: 'a' });
+  cache.set('https://b.com', { id: 'b' });
+  cache.set('https://c.com', { id: 'c' });
+  // At capacity, adding d should evict a (LRU)
+  cache.set('https://d.com', { id: 'd' });
+  assert.equal(cache.get('https://a.com'), undefined);
+  assert.ok(cache.get('https://b.com'));
+  assert.ok(cache.get('https://c.com'));
+  assert.ok(cache.get('https://d.com'));
+});
+
+test('PreviewCache respects TTL expiry', async () => {
+  const cache = new PreviewCache({ maxSize: 10, ttlMs: 50 });
+  cache.set('https://example.com', { title: 'Example' });
+  assert.ok(cache.get('https://example.com'));
+  // Wait for expiry
+  await new Promise(resolve => setTimeout(resolve, 60));
+  assert.equal(cache.get('https://example.com'), undefined);
+});
+
+test('PreviewCache cleanup removes expired entries', async () => {
+  const cache = new PreviewCache({ maxSize: 10, ttlMs: 50 });
+  cache.set('https://a.com', { id: 'a' });
+  cache.set('https://b.com', { id: 'b' });
+  await new Promise(resolve => setTimeout(resolve, 60));
+  const removed = cache.cleanup();
+  assert.equal(removed, 2);
+  assert.equal(cache.get('https://a.com'), undefined);
+  assert.equal(cache.get('https://b.com'), undefined);
+});
+
+test('PreviewCache stats returns correct counts', () => {
+  const cache = new PreviewCache({ maxSize: 10, ttlMs: 5000 });
+  cache.set('https://a.com', { id: 'a' });
+  cache.set('https://b.com', { id: 'b' });
+  const stats = cache.stats();
+  assert.equal(stats.size, 2);
+  assert.equal(stats.maxSize, 10);
+  assert.equal(stats.ttlMs, 5000);
+  assert.equal(stats.expiredCount, 0);
+  assert.equal(stats.activeCount, 2);
+});
+
+test('PreviewCache clear removes all entries', () => {
+  const cache = new PreviewCache({ maxSize: 10, ttlMs: 5000 });
+  cache.set('https://a.com', { id: 'a' });
+  cache.set('https://b.com', { id: 'b' });
+  cache.clear();
+  assert.equal(cache.get('https://a.com'), undefined);
+  assert.equal(cache.get('https://b.com'), undefined);
+});
+
+test('PreviewCache normalizes URLs to lowercase for keys', () => {
+  const cache = new PreviewCache({ maxSize: 10, ttlMs: 5000 });
+  cache.set('https://EXAMPLE.COM/page', { title: 'Example' });
+  const entry = cache.get('https://example.com/page');
+  assert.ok(entry);
+  assert.equal(entry.data.title, 'Example');
+});
+
+test('PreviewCache updates existing keys in place (no eviction)', () => {
+  const cache = new PreviewCache({ maxSize: 2, ttlMs: 5000 });
+  cache.set('https://a.com', { id: 'a' });
+  cache.set('https://b.com', { id: 'b' });
+  // Update a — should NOT evict b since a already exists
+  cache.set('https://a.com', { id: 'a-updated' });
+  assert.ok(cache.get('https://b.com'));
+  assert.equal(cache.get('https://a.com').data.id, 'a-updated');
+});
+
+// ---- PreviewCoalescer tests ----
+
+test('PreviewCoalescer returns same result for concurrent calls', async () => {
+  const coalescer = new PreviewCoalescer();
+  let callCount = 0;
+  const fn = async () => {
+    callCount++;
+    await new Promise(resolve => setTimeout(resolve, 50));
+    return { result: 'ok' };
+  };
+
+  // Start two concurrent calls for the same key
+  const [r1, r2] = await Promise.all([
+    coalescer.run('https://example.com', fn),
+    coalescer.run('https://example.com', fn),
+  ]);
+
+  assert.equal(r1.result, 'ok');
+  assert.equal(r2.result, 'ok');
+  assert.equal(callCount, 1); // Only one call should have been made
+});
+
+test('PreviewCoalescer allows different keys to run independently', async () => {
+  const coalescer = new PreviewCoalescer();
+  let aCount = 0;
+  let bCount = 0;
+  const fnA = async () => { aCount++; await new Promise(r => setTimeout(r, 50)); return 'a'; };
+  const fnB = async () => { bCount++; await new Promise(r => setTimeout(r, 50)); return 'b'; };
+
+  const [r1, r2] = await Promise.all([
+    coalescer.run('key-a', fnA),
+    coalescer.run('key-b', fnB),
+  ]);
+
+  assert.equal(r1, 'a');
+  assert.equal(r2, 'b');
+  assert.equal(aCount, 1);
+  assert.equal(bCount, 1);
+});
+
+test('PreviewCoalescer sequential calls both execute', async () => {
+  const coalescer = new PreviewCoalescer();
+  let count = 0;
+  const fn = async () => { count++; await new Promise(r => setTimeout(r, 30)); return 'ok'; };
+
+  // Sequential: first completes before second starts
+  const r1 = await coalescer.run('key', fn);
+  const r2 = await coalescer.run('key', fn);
+
+  assert.equal(r1, 'ok');
+  assert.equal(r2, 'ok');
+  assert.equal(count, 2); // Both should execute since they're sequential
+});
+
+test('PreviewCoalescer cancelAll clears pending promises', async () => {
+  const coalescer = new PreviewCoalescer();
+  let count = 0;
+  const fn = async () => { count++; await new Promise(r => setTimeout(r, 1000)); return 'ok'; };
+
+  // Start a long-running call
+  const p = coalescer.run('key', fn);
+  assert.equal(count, 1);
+
+  // Cancel it
+  coalescer.cancelAll();
+
+  // Start another call for the same key — should execute fresh
+  const r2 = await coalescer.run('key', fn);
+  assert.equal(r2, 'ok');
+  assert.equal(count, 2); // First was cancelled, second executed
+});
+
+test('PreviewCoalescer propagates errors from fn', async () => {
+  const coalescer = new PreviewCoalescer();
+  const errFn = async () => { throw new Error('fetch failed'); };
+
+  await assert.rejects(
+    coalescer.run('key', errFn),
+    { message: 'fetch failed' },
+  );
+
+  // After error, the key should be freed for a fresh call
+  let count = 0;
+  const okFn = async () => { count++; return 'ok'; };
+  const r = await coalescer.run('key', okFn);
+  assert.equal(r, 'ok');
+  assert.equal(count, 1);
+});
+
+// ---- Integration: Cache + Coalescer pressure scenarios ----
+
+test('Cache hit skips coalescer for repeated requests', async () => {
+  const cache = new PreviewCache({ maxSize: 256, ttlMs: 300_000 });
+  let fetchCount = 0;
+  const fn = async () => { fetchCount++; return { title: 'cached' }; };
+
+  // First request — cache miss, fetches
+  let cached = cache.get('https://example.com');
+  if (!cached) {
+    const data = await fn();
+    cache.set('https://example.com', data);
+    cached = cache.get('https://example.com');
+  }
+
+  assert.equal(fetchCount, 1);
+
+  // Second request — cache hit, no fetch
+  const cached2 = cache.get('https://example.com');
+  assert.ok(cached2);
+  assert.equal(fetchCount, 1); // Still 1
+});
+
+test('Coalescer prevents duplicate fetches under concurrent load', async () => {
+  const cache = new PreviewCache({ maxSize: 256, ttlMs: 300_000 });
+  const coalescer = new PreviewCoalescer();
+  let fetchCount = 0;
+
+  const fn = async () => {
+    fetchCount++;
+    await new Promise(r => setTimeout(r, 100));
+    return { title: 'concurrent' };
+  };
+
+  // Simulate 5 concurrent requests for the same URL
+  const results = await Promise.all([
+    coalescer.run('https://example.com', async () => {
+      const cached = cache.get('https://example.com');
+      if (cached) return cached.data;
+      const data = await fn();
+      cache.set('https://example.com', data);
+      return data;
+    }),
+    coalescer.run('https://example.com', async () => {
+      const cached = cache.get('https://example.com');
+      if (cached) return cached.data;
+      const data = await fn();
+      cache.set('https://example.com', data);
+      return data;
+    }),
+    coalescer.run('https://example.com', async () => {
+      const cached = cache.get('https://example.com');
+      if (cached) return cached.data;
+      const data = await fn();
+      cache.set('https://example.com', data);
+      return data;
+    }),
+    coalescer.run('https://example.com', async () => {
+      const cached = cache.get('https://example.com');
+      if (cached) return cached.data;
+      const data = await fn();
+      cache.set('https://example.com', data);
+      return data;
+    }),
+    coalescer.run('https://example.com', async () => {
+      const cached = cache.get('https://example.com');
+      if (cached) return cached.data;
+      const data = await fn();
+      cache.set('https://example.com', data);
+      return data;
+    }),
+  ]);
+
+  assert.equal(fetchCount, 1); // Only one fetch despite 5 concurrent requests
+  results.forEach(r => assert.equal(r.title, 'concurrent'));
+});
+
+test('Cache TTL expiry allows fresh fetch on next request', async () => {
+  const cache = new PreviewCache({ maxSize: 256, ttlMs: 100 });
+  let fetchCount = 0;
+
+  const fn = async () => { fetchCount++; return { version: fetchCount }; };
+
+  // First fetch
+  cache.set('https://example.com', await fn());
+  assert.equal(fetchCount, 1);
+
+  // Cache hit
+  assert.ok(cache.get('https://example.com'));
+  assert.equal(fetchCount, 1);
+
+  // Wait for expiry
+  await new Promise(r => setTimeout(r, 150));
+
+  // Cache miss — would trigger a fresh fetch
+  assert.equal(cache.get('https://example.com'), undefined);
+  cache.set('https://example.com', await fn());
+  assert.equal(fetchCount, 2);
+});

--- a/tests/mobile-apk-flow-regression.test.js
+++ b/tests/mobile-apk-flow-regression.test.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const indexHtmlPath = path.join(__dirname, '..', 'public', 'index.html');
+const apiClientPath = path.join(__dirname, '..', 'public', 'lib', 'api-client.js');
 const updateManagerPath = path.join(__dirname, '..', 'public', 'mobile', 'update-manager.js');
 
 function read(filePath) {
@@ -17,19 +18,18 @@ test('native onboarding requires backend configuration before app boot continues
   assert.match(indexHtml, /if \(getApiBaseUrl\(\)\) return true;/);
   assert.match(indexHtml, /window\.prompt\(`Enter your Miso server URL/);
   assert.match(indexHtml, /window\.alert\('A backend URL is required before the APK can sign in\.'/);
-  assert.match(indexHtml, /const result = await verifyBackendUrl\(normalized\);/);
+  assert.match(indexHtml, /const result = await testBackendConnection\(normalized\);/);
   assert.match(indexHtml, /const backendReady = await ensureMobileBackendConfigured\(\);/);
   assert.match(indexHtml, /if \(!backendReady\) \{/);
 });
 
 test('auth-required fetch path will not immediately relaunch login during callback settle window', () => {
-  const indexHtml = read(indexHtmlPath);
+  const apiClient = read(apiClientPath);
 
-  assert.match(indexHtml, /if \(mobileAuthInFlight\) \{/);
-  assert.match(indexHtml, /throw new Error\('Authentication pending'\);/);
-  assert.match(indexHtml, /const justSettled = mobileAuthSettledAt && \(Date\.now\(\) - mobileAuthSettledAt\) < 4000;/);
-  assert.match(indexHtml, /throw new Error\('Authentication settling'\);/);
-  assert.match(indexHtml, /mobileAuthSettledAt = Date\.now\(\);/);
+  assert.match(apiClient, /if \(mobileAuthInFlight\) \{/);
+  assert.match(apiClient, /throw new Error\('Authentication pending'\);/);
+  assert.match(apiClient, /const justSettled = mobileAuthSettledAt && \(Date\.now\(\) - mobileAuthSettledAt\) < 4000;/);
+  assert.match(apiClient, /throw new Error\('Authentication settling'\);/);
 });
 
 test('manual OTA affordance still exists in the native shell header', () => {


### PR DESCRIPTION
Fixes #544

- Add `PreviewCache` LRU cache (configurable maxSize/TTL via env vars)
- Add `PreviewCoalescer` to deduplicate concurrent requests for the same URL
- Integrate cache + coalescing into `/api/link-preview` route
- Add per-phase timeout controls: DNS, connect+headers, body-read
- Add periodic cache cleanup (60s interval)
- 17 unit tests for cache, coalescer, and integration scenarios