### PR TITLE
ci: upgrade pr-reviewer-action to v1.2.3 (tool loop, carry-forward verdicts)

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Review PR with reusable AI reviewer
         if: github.event_name == 'pull_request'
         id: review
-        uses: misospace/pr-reviewer-action@e891235e8e3e75824b88fb696b1f7b4816122737 # v1.2.2
+        uses: misospace/pr-reviewer-action@59c7a0596b0d0b515ef9137f7acb985115f4c1d8 # v1.2.3
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "3"
@@ -51,11 +51,12 @@ jobs:
           ai_fallback_api_key: ${{ secrets.LITELLM_API_KEY }}
           review_routing_mode: auto
           ai_smart_base_url: ${{ vars.LITELLM_URL }}
-          ai_smart_api_format: ${{ vars.SMART_FORMAT || vars.FALLBACK_FORMAT }}
-          ai_smart_model: ${{ vars.SMART_MODEL || vars.FALLBACK_MODEL }}
+          ai_smart_api_format: ${{ vars.SMART_FORMAT }}
+          ai_smart_model: ${{ vars.SMART_MODEL }}
           ai_smart_api_key: ${{ secrets.LITELLM_API_KEY }}
           context_limit_mode: normal
-          tool_mode: plan_execute_once
+          tool_mode: plan_execute_loop
+          tool_max_rounds: "2"
           tool_max_requests: "4"
           tool_planning_timeout_sec: "45"
           tool_planning_max_context_bytes: "15000"


### PR DESCRIPTION
Upgrades to [pr-reviewer-action v1.2.3](https://github.com/misospace/pr-reviewer-action/releases/tag/v1.2.3).

## What this brings

- **Cumulative incremental verdicts**: when a review requests changes, its findings are carried into the next push's incremental review, which must explicitly resolve each one — fixing one of three blockers can no longer rubber-stamp the other two. The latest review always lists what was resolved and what's still open.
- **Superseded reviews keep their content**: old reviews are hidden (minimized) and their verdicts dismissed, but the text is no longer overwritten — expanding a hidden review still shows what it said.
- **Multi-turn tool research** — `tool_mode: plan_execute_loop` with `tool_max_rounds: "2"`: the model can now react to what its evidence tools returned and request follow-ups (read the changed file → grep for its callers). The 4-request budget is now shared across rounds; each extra round costs one additional planning call against the review endpoint.
- **Explicit smart wiring**: `ai_smart_model`/`ai_smart_api_format` now read `vars.SMART_MODEL`/`vars.SMART_FORMAT` directly (both are explicitly set at the org level), instead of coalescing to the fallback vars.
- **Dirty-baseline escalation** (on by default): incremental reviews of a PR whose previous review found issues run on the smart model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)