### PR TITLE
feat(pr-review): /ai-review comment command to force a re-review

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -5,9 +5,11 @@ on:
     branches: ["main"]
     types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -16,14 +18,24 @@ permissions:
 
 jobs:
   review:
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.draft) || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '/ai-review')) }}
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve PR head for comment trigger
+        id: prctx
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          echo "head_sha=$sha" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || steps.prctx.outputs.head_sha || github.sha }}
 
       - name: Generate bot token
         id: app-token
@@ -32,12 +44,43 @@ jobs:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
+      # The gate script ships with the action; the authorization decision
+      # (commenter must hold write/admin) must run before any review work.
+      - name: Check out re-review command gate
+        if: github.event_name == 'issue_comment'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: misospace/pr-reviewer-action
+          ref: bfe54bcac9959ca258da86482caa0f7b16d681c3 # v1.2.8
+          path: .ai-review-gate
+          persist-credentials: false
+
+      - name: Authorize re-review command
+        id: cmd
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENTER_LOGIN: ${{ github.event.comment.user.login }}
+          IS_PR_COMMENT: ${{ github.event.issue.pull_request != null }}
+        run: bash .ai-review-gate/scripts/parse_review_command.sh
+
+      - name: Acknowledge authorized re-review
+        if: github.event_name == 'issue_comment' && steps.cmd.outputs.should_review == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" -f content=rocket --silent || true
+
       - name: Review PR with reusable AI reviewer
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || steps.cmd.outputs.should_review == 'true'
         id: review
-        uses: misospace/pr-reviewer-action@59c7a0596b0d0b515ef9137f7acb985115f4c1d8 # v1.2.3
+        uses: misospace/pr-reviewer-action@bfe54bcac9959ca258da86482caa0f7b16d681c3 # v1.2.8
         with:
           github_token: ${{ steps.app-token.outputs.token }}
+          pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          force_review: ${{ github.event_name == 'issue_comment' && 'true' || 'false' }}
           ai_primary_retries: "3"
           ai_primary_retry_delay_sec: "15"
           ai_base_url: ${{ vars.LITELLM_URL }}


### PR DESCRIPTION
Wires the `/ai-review` re-review command into this repo, completing [pr-reviewer-action#231](https://github.com/misospace/pr-reviewer-action/issues/231).

**What it does:** commenting `/ai-review` on a PR forces a fresh AI review even when nothing changed (`force_review` bypasses the diff-unchanged guard) — for when the model behind the LiteLLM alias changed, standards were updated, or the first review was flaky. An authorized command gets a 🚀 reaction; the review runs against the PR head.

**Authorization (the important part):** `issue_comment` workflows run with base-repo secrets, so the command is gated by the action's tested `parse_review_command.sh`: the commenter must hold **write/admin** via the collaborators API (`author_association` is never trusted), the command must be its own line, and non-PR issues are ignored. Unauthorized comments are a silent no-op. All event data reaches scripts via `env`, never inline interpolation.

Also bumps the action pin to [v1.2.8](https://github.com/misospace/pr-reviewer-action/releases/tag/v1.2.8) (ships `force_review` + the gate script; otherwise byte-identical default behavior), making the PR self-contained instead of racing the Renovate bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)