### PR TITLE
ci: label-driven AI re-review (v1.2.9)

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -3,13 +3,13 @@ name: AI PR Review
 on:
   pull_request:
     branches: ["main"]
-    types: [opened, reopened, synchronize, ready_for_review]
+    # `labeled` enables the one-click re-review: add the `ai-review` label to
+    # force a fresh review (only write/triage can label — self-authorizing).
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
   workflow_dispatch:
-  issue_comment:
-    types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -18,24 +18,14 @@ permissions:
 
 jobs:
   review:
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.draft) || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '/ai-review')) }}
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve PR head for comment trigger
-        id: prctx
-        if: github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
-          echo "head_sha=$sha" >> "$GITHUB_OUTPUT"
-
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || steps.prctx.outputs.head_sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Generate bot token
         id: app-token
@@ -44,43 +34,12 @@ jobs:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
-      # The gate script ships with the action; the authorization decision
-      # (commenter must hold write/admin) must run before any review work.
-      - name: Check out re-review command gate
-        if: github.event_name == 'issue_comment'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          repository: misospace/pr-reviewer-action
-          ref: bfe54bcac9959ca258da86482caa0f7b16d681c3 # v1.2.8
-          path: .ai-review-gate
-          persist-credentials: false
-
-      - name: Authorize re-review command
-        id: cmd
-        if: github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: ${{ github.repository }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          COMMENTER_LOGIN: ${{ github.event.comment.user.login }}
-          IS_PR_COMMENT: ${{ github.event.issue.pull_request != null }}
-        run: bash .ai-review-gate/scripts/parse_review_command.sh
-
-      - name: Acknowledge authorized re-review
-        if: github.event_name == 'issue_comment' && steps.cmd.outputs.should_review == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-        run: gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" -f content=rocket --silent || true
-
       - name: Review PR with reusable AI reviewer
-        if: github.event_name == 'pull_request' || steps.cmd.outputs.should_review == 'true'
+        if: github.event_name == 'pull_request'
         id: review
-        uses: misospace/pr-reviewer-action@bfe54bcac9959ca258da86482caa0f7b16d681c3 # v1.2.8
+        uses: misospace/pr-reviewer-action@4126a2701a5e9adcf7c48ac6eb678e2e3a2bb2a0 # v1.2.9
         with:
           github_token: ${{ steps.app-token.outputs.token }}
-          pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
-          force_review: ${{ github.event_name == 'issue_comment' && 'true' || 'false' }}
           ai_primary_retries: "3"
           ai_primary_retry_delay_sec: "15"
           ai_base_url: ${{ vars.LITELLM_URL }}


### PR DESCRIPTION
Adding the `ai-review` label to a PR now forces a re-review: pr-reviewer-action v1.2.9 handles the `labeled` event natively (skipping unrelated labels) and removes the label after publishing, so re-adding it re-triggers. Labeling is restricted to write/triage, so the trigger is self-authorizing.

This replaces the `/ai-review` comment-command wiring, which is removed along with its authorization gate; the action pin is bumped to v1.2.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)