### PR TITLE
chore: manage Dispatch labels from labels.yaml

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,76 @@
+---
+# Status
+- name: status/backlog
+  color: "cfd3d7"
+  description: Not ready for worker pickup yet.
+- name: status/ready
+  color: "0e8a16"
+  description: Ready for Dispatch worker pickup.
+- name: status/in-progress
+  color: "fbca04"
+  description: Work has been claimed or started.
+- name: status/in-review
+  color: "5319e7"
+  description: Pull request or human review is in progress.
+- name: status/done
+  color: "0e8a16"
+  description: Work is complete.
+# Priority
+- name: priority/p0
+  color: "b60205"
+  description: Critical priority.
+- name: priority/p1
+  color: "d93f0b"
+  description: High priority.
+- name: priority/p2
+  color: "fbca04"
+  description: Normal priority.
+- name: priority/p3
+  color: "0e8a16"
+  description: Low priority.
+# Type / Classification
+- name: bug
+  color: "d73a4a"
+  description: Something is not working.
+- name: enhancement
+  color: "a2eeef"
+  description: New feature or improvement.
+- name: documentation
+  color: "0075ca"
+  description: Documentation work.
+- name: dependencies
+  color: "0366d6"
+  description: Dependency update or maintenance.
+- name: audit
+  color: "bfdadc"
+  description: Audit, review, or investigation work.
+- name: pr-review-fix
+  color: "c5def5"
+  description: Follow-up work from pull request review.
+- name: ai-review
+  color: "b4f8f8"
+  description: Request an AI pull request review.
+- name: umbrella
+  color: "5319e7"
+  description: Parent issue that may need decomposition.
+# Dispatch / Workflow
+- name: needs-info
+  color: "d4c5f9"
+  description: More information is needed before work can continue.
+- name: needs-human
+  color: "e99695"
+  description: Human input or decision is required.
+- name: needs-escalation
+  color: "b60205"
+  description: Needs escalated lane attention.
+- name: blocked
+  color: "e11d21"
+  description: Progress is blocked.
+# Stable Agents
+- name: agent/saffron-normal
+  color: "1d76db"
+  description: Stable normal-lane Saffron worker.
+- name: agent/saffron-escalated
+  color: "0052cc"
+  description: Stable escalated-lane Saffron worker.
+# Repo-specific labels can be appended below. Unknown labels are not pruned.

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Label Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Preview label changes without applying them.
+        required: false
+        type: boolean
+        default: false
+  push:
+    branches: ["main"]
+    paths: [".github/labels.yaml"]
+
+permissions:
+  contents: read
+
+jobs:
+  main:
+    name: Label Sync - Sync Labels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/labels.yaml
+
+      - name: Sync Labels
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
+        with:
+          config-file: .github/labels.yaml
+          delete-other-labels: false
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}


### PR DESCRIPTION
## Why

Dispatch worker queues and PR workflows depend on stable labels such as `status/*`, `priority/*`, `agent/*`, and `ai-review`. This moves the canonical Dispatch-managed label set into `.github/labels.yaml` so label setup is version-controlled instead of manual GitHub UI state.

## What changed

- Added `.github/labels.yaml` with Dispatch status, priority, classification, workflow, stable agent, `ai-review`, and active `umbrella` labels.
- Added a pinned label sync workflow using `EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a`.
- The workflow supports `workflow_dispatch` and runs when `.github/labels.yaml` changes on `main`.

## Safety

- Add/update only for the first rollout.
- Unknown labels are not pruned: `delete-other-labels: false`.
- Repo-specific labels, Renovate labels, and dynamic `agent/*` labels remain untouched unless explicitly listed in the config.
- No Dispatch runtime state, app behavior, DB data, issues, or home-ops files were changed.

## Validation

- Parsed `.github/labels.yaml` as YAML.
- Parsed `.github/workflows/label-sync.yaml` as YAML.
- Verified required `status/*`, `priority/*`, stable `agent/*`, and `ai-review` labels are present.
- Verified pinned `actions/checkout` and pinned `EndBug/label-sync` references.
- Verified minimal workflow permissions: `contents: read`, `issues: write`.
- Verified `delete-other-labels: false` is present.
- Generated a local label report from the public GitHub Labels API: create=8, update=15, delete=0.

Dispatch worker labels are now version-controlled.