### PR TITLE
chore(ai-review): adopt pr-reviewer v1.3.0 native_loop + org-var tokens

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Review PR with reusable AI reviewer
         if: github.event_name == 'pull_request'
         id: review
-        uses: misospace/pr-reviewer-action@c87ab3fb2f8de58756c47185b0cac18c71210944 # v1.2.11
+        uses: misospace/pr-reviewer-action@3479bf51ab9133414ae07af783bff985d3929884 # v1.3.0
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "3"
@@ -49,6 +49,7 @@ jobs:
           ai_model: ${{ vars.PRIMARY_MODEL }}
           ai_api_key: ${{ secrets.LITELLM_API_KEY }}
           ai_response_format: json_object
+          ai_max_tokens: ${{ vars.AI_MAX_TOKENS || '16000' }}
           ai_fallback_base_url: ${{ vars.LITELLM_URL }}
           ai_fallback_api_format: ${{ vars.FALLBACK_FORMAT }}
           ai_fallback_model: ${{ vars.FALLBACK_MODEL }}
@@ -61,12 +62,13 @@ jobs:
           context_limit_mode: normal
           ci_status_check: "true"
           ci_timeout_sec: "600"
-          tool_mode: plan_execute_loop
+          tool_mode: native_loop
           tool_max_rounds: "2"
           tool_max_requests: "4"
-          tool_planning_timeout_sec: "45"
+          tool_loop_wall_clock_sec: "300"
+          tool_planning_timeout_sec: "300"
           tool_planning_max_context_bytes: "15000"
-          tool_planning_max_tokens: "1500"
+          tool_planning_max_tokens: "16000"
           tool_max_response_bytes: "12000"
           tool_allowed_gh_api_repos: "*"
           tool_request_timeout_sec: "15"


### PR DESCRIPTION
Part of the misospace v1.3.0 fanout — identical to the dispatch canary (misospace/dispatch#374). Pin v1.2.11 -> **v1.3.0**, tool_mode -> **native_loop**, `ai_max_tokens` -> `${{ vars.AI_MAX_TOKENS || '16000' }}`, plus thinking-model loop budgets (planning tokens 1500->16000, timeout 45->300, wall-clock 300). Self-validates via the head workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)