### PR TITLE
Harden container runtime defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,22 @@
 FROM node:24-alpine
+
 WORKDIR /app
+
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
+
 COPY . .
+
+# Ensure writable data directories exist and are owned by the non-root user
+RUN mkdir -p /app/data && chown -R node:node /app
+
 ENV NODE_ENV=production
+
 EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:3000/api/health || exit 1
+
+USER node
+
 CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ docker-compose up -d
 ```bash
 docker run -d --name miso-chat \
   -p 3000:3000 \
+  -v miso-chat-data:/app/data \
   -e GATEWAY_URL=ws://your-gateway:18789 \
   -e SESSION_SECRET=your-secret \
   ghcr.io/misospace/miso-chat:latest
+
+> **Note:** The image runs as a non-root `node` user and includes a healthcheck on `/api/health`.
+> Mount `/app/data` to persist the SQLite database across container restarts.
 ```
 
 ## Configuration
@@ -53,7 +57,8 @@ docker run -d --name miso-chat \
 | `CSRF_TRUSTED_ORIGINS` | No | - | Comma-separated extra origins allowed for state-changing requests |
 | `OIDC_ENABLED` | No | `false` | Enable OIDC auth |
 | `LOCAL_USERS` | If local | `admin:password123` | Users (user:pass) |
-| `REDIS_URL` | No | - | Optional Redis/Dragonfly session store |
+| `REDIS_URL` | **Yes in production** | - | Redis/Dragonfly session store (required for production) |
+| `ALLOW_MEMORY_STORE` | No | `false` | Override production Redis requirement for development/testing |
 | `CAPACITOR_COOKIES_ENABLED` | No | `true` | Enable Capacitor cookie bridge for native app builds |
 | `PUSH_NOTIFICATIONS_ENABLED` | No | `false` | Reserved for future browser push support (production web-push NOT implemented) |
 | `PUSH_VAPID_PUBLIC_KEY` | If push enabled | - | Public VAPID key (reserved for future implementation) |
@@ -362,7 +367,9 @@ env:
   REDIS_URL: "redis://{{ .Release.Name }}-dragonfly:6379"
 ```
 
-This is optional. If `REDIS_URL` is not set, miso-chat falls back to in-memory sessions.
+In **production**, `REDIS_URL` is required — without it, miso-chat will refuse to start (fail-fast). This prevents silent data loss from in-memory session stores across restarts or multi-instance deployments.
+
+For local development and testing, the in-memory store is used by default. If you need MemoryStore in production for a specific reason, set `ALLOW_MEMORY_STORE=true` to override the check.
 
 ## OTA Updates
 

--- a/lib/auth-session.js
+++ b/lib/auth-session.js
@@ -97,8 +97,14 @@ function buildSessionConfig({ authMode }) {
     });
 
     console.log('✅ Session store: Redis (enabled)');
+  } else if (process.env.ALLOW_MEMORY_STORE === 'true') {
+    console.warn('⚠️ Session store: MemoryStore (REDIS_URL not set, ALLOW_MEMORY_STORE=true)');
+  } else if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      'REDIS_URL is required in production. Set REDIS_URL or allow in-memory sessions with ALLOW_MEMORY_STORE=true.'
+    );
   } else {
-    console.warn('⚠️ Session store: MemoryStore (REDIS_URL not set)');
+    console.warn('⚠️ Session store: MemoryStore (REDIS_URL not set) — not recommended for production.');
   }
 
   return sessionConfig;


### PR DESCRIPTION
Fixes #543

**Changes:**

- **Non-root user**: Dockerfile now runs as `node` user (not root). Added `RUN mkdir -p /app/data && chown -R node:node /app` to ensure writable data directories.
- **Healthcheck**: Added `HEALTHCHECK` instruction using `/api/health` endpoint (30s interval, 5s timeout, 10s start period, 3 retries).
- **Production fail-fast for MemoryStore**: When `NODE_ENV=production` and `REDIS_URL` is not set, the app throws on startup instead of silently falling back to in-memory sessions. Override with `ALLOW_MEMORY_STORE=true`.
- **README alignment**: Updated Docker run example with volume mount, documented non-root user and healthcheck, clarified Redis requirement for production, added `ALLOW_MEMORY_STORE` env var documentation.