### PR TITLE
chore: release v0.4.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miso-chat",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miso-chat",
-      "version": "0.4.13",
+      "version": "0.4.14",
       "dependencies": {
         "@capacitor/android": "^8.1.0",
         "@capacitor/app": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miso-chat",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "private": true,
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
## Release v0.4.14

Bumps `package.json` to `0.4.14` and matches `package-lock.json`.

### Highlights since v0.4.13
- Container runtime defaults hardened (#590)
- Auth/session boundary extracted into `lib/auth-session.js` (#570)
- `SESSION_COOKIE_DOMAIN` env var for subdomain isolation (#562)
- Update manager consolidated; stale APK logic removed (#564)
- `/ai-review` comment command for forced PR re-reviews (#580)
- Label-driven AI re-review + CI result routing (#581, #583, #587)
- TAP reporter output for CI test results (#577)
- ESLint actually runs on server.js / lib / tests (#571)
- Dispatch labels now managed from `labels.yaml` (#586)
- Renovate/dependency updates: `@capgo/capacitor-updater`, `google-services`, `better-sqlite3`, `multer`, `pr-reviewer-action`

### Validation (CI on this PR)
- lint: pending
- test: pending
- audit: pending