### PR TITLE
fix: remove CSP nonce that blocks inline scripts

### DIFF
--- a/security.js
+++ b/security.js
@@ -82,13 +82,11 @@ function getServerOrigin(req) {
   return normalizeOrigin(`${protocol}://${host}`);
 }
 
-function generateNonce() {
-  return crypto.randomBytes(16).toString('base64');
-}
 /**
- * NOTE: CSP is no longer a static CONTENT_SECURITY_POLICY constant.
- * It is now set dynamically in securityHeaders() with per-request nonces,
- * which is more secure (prevents script injection even if nonce source leaks).
+ * NOTE: CSP is set dynamically in securityHeaders().
+ * Since index.html is served as a static file (no template rendering),
+ * nonce-based inline script restriction is not feasible.
+ * 'unsafe-inline' is used for script-src to allow inline scripts.
  */
 
 // ---------------------------------------------------------------------------
@@ -192,8 +190,6 @@ function csrfTokenCheck(req, res, next) {
 }
 
 function securityHeaders(req, res, next) {
-  const nonce = generateNonce();
-  if (res.locals) res.locals.cspNonce = nonce;
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('X-Frame-Options', 'DENY');
   res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
@@ -205,7 +201,7 @@ function securityHeaders(req, res, next) {
     "frame-ancestors 'none'",
     "img-src 'self' data:",
     `style-src 'self' 'unsafe-inline'`,
-    `script-src 'self' 'nonce-${nonce}'`,
+    "script-src 'self' 'unsafe-inline'",
     "connect-src 'self' ws: wss:",
     "form-action 'self'",
   ].join('; '));

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -44,7 +44,7 @@ test('securityHeaders sets required baseline headers including CSP', () => {
   assert.match(csp, /default-src 'self'/);
   assert.match(csp, /object-src 'none'/);
   assert.match(csp, /frame-ancestors 'none'/);
-  assert.match(csp, /script-src 'self' 'nonce-[A-Za-z0-9+/=]+/);
+  assert.match(csp, /script-src 'self' 'unsafe-inline'/);
   assert.match(csp, /style-src 'self' 'unsafe-inline'/);
 });
 


### PR DESCRIPTION
Fixes #602

## Problem

The CSP `script-src` directive used a per-request nonce (`nonce-${nonce}`) to restrict inline scripts. However, `index.html` is served as a static file via `express.static()` — the nonce stored in `res.locals.cspNonce` was never injected into the HTML template. This caused all inline `<script>` tags to be blocked by CSP, leaving the app stuck on "Connecting to OpenClaw Gateway".

## Fix

- Remove nonce-based `script-src` restriction and use `script-src 'self' 'unsafe-inline'` instead
- All scripts are same-origin; no third-party script sources are loaded
- Remove unused `generateNonce()` function
- Update stale CSP comment to document the rationale

## Trade-off

`'unsafe-inline'` reduces CSP protection against XSS via inline script injection. Since all scripts are same-origin and no user-generated content is rendered as raw HTML in the main page, this risk is acceptable for now. A follow-up (Option B: extract inline JS to external files) can be done for v0.5.0.

<!-- saffron-worker-footer -->
Worker: saffron-normal
Model: litellm/nvidia