### PR TITLE
fix(release): detect missing tags

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -99,8 +99,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          EXISTING_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" --jq .object.sha 2>/dev/null || true)
-          if [ -n "$EXISTING_SHA" ]; then
+          if EXISTING_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$VERSION" --jq .object.sha 2>/dev/null); then
             if [ "$EXISTING_SHA" != "$MERGE_SHA" ]; then
               echo "Tag $VERSION already points to $EXISTING_SHA"
               exit 1


### PR DESCRIPTION
`gh api` writes a 404 response body to stdout, so the previous `|| true` path mistook missing-tag JSON for an existing SHA. Branch on the API command status so release recovery can create a genuinely missing tag.

Validated against the absent `0.4.15` tag.