### PR TITLE
fix(release): avoid tag visibility race

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -122,7 +122,6 @@ jobs:
           else
             gh release create "$VERSION" \
               --repo "$GITHUB_REPOSITORY" \
-              --verify-tag \
               --title "$VERSION" \
               --generate-notes
           fi


### PR DESCRIPTION
The workflow already creates or verifies the exact tag ref and SHA. Drop the redundant `--verify-tag` lookup, which can briefly miss a freshly created ref and block release creation.

Observed on the successful `0.4.15` tag creation in run 27927835135.