### PR TITLE
fix(ci): correct invalid action SHAs in android-release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -33,12 +33,12 @@ jobs:
           git checkout ${{ github.event.release.tag_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c2e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
 
       - name: Setup Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec502508b2fdc7f6654 # v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: temurin
           java-version: '21'


### PR DESCRIPTION
## Problem

The Android build workflow (`android-release.yml`) has two invalid action SHAs that cause it to fail immediately at action resolution:

- `actions/setup-node` — SHA `48b55a011bda9f5d6aeb4c2d9c2e8dae4041e` has a typo. The correct SHA is `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (v6.4.0), matching all other workflows.
- `actions/setup-java` — SHA `be666c2fcd27ec809703dec502508b2fdc7f6654` is no longer valid. The correct SHA is `ad2b38190b15e4d6bdf0c97fb4fca8412226d287` (v5.3.0).

This broke the Android release builds for v0.4.14 and v0.4.15. The last successful Android build was v0.4.13. The mobile app never received the CSP fix (#604) or missing JS files (#605), so it's still stuck on 'Connecting to OpenClaw Gateway'.

## Fix

Update both SHAs to the correct values matching the rest of the repo's workflows.

## Verification

- All other SHAs in the workflow verified valid (checkout, setup-android, gh-release, upload-artifact)
- After merge, re-trigger the Android build for v0.4.15 via workflow_dispatch to publish the APK + OTA bundle