### PR TITLE
fix: service worker serving stale HTML with old CSP headers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2691,6 +2691,15 @@
             if (!('serviceWorker' in navigator)) return;
             try {
                 serviceWorkerRegistration = await navigator.serviceWorker.register('/mobile/sw.js');
+                // When a new service worker takes over, reload once so the
+                // page picks up the fresh HTML + assets.
+                let reloaded = false;
+                navigator.serviceWorker.addEventListener('controllerchange', () => {
+                    if (!reloaded) {
+                        reloaded = true;
+                        window.location.reload();
+                    }
+                });
             } catch (error) {
                 console.warn('Service worker registration failed:', error);
             }

--- a/public/mobile/sw.js
+++ b/public/mobile/sw.js
@@ -1,22 +1,77 @@
 // Service Worker for PWA + notifications
-const CACHE_NAME = 'openclaw-chat-v1';
-const urlsToCache = [
-  '/',
-  '/index.html',
-  '/login.html'
+//
+// Strategy: network-first for navigation/document requests so users always
+// get fresh HTML (and fresh CSP headers). Cache-first for static assets
+// that are immutable per version. Push + notification click handlers
+// remain unchanged.
+
+const CACHE_NAME = 'openclaw-chat-v2';
+const STATIC_ASSETS = [
+  '/login.html',
+  '/favicon.ico',
+  '/favicon-32x32.png',
+  '/favicon-16x16.png',
+  '/apple-touch-icon.png',
+  '/manifest.json',
 ];
+
+// Requests that should always go to the network first (HTML documents,
+// API calls, SSE).  If the network fails we fall back to cache.
+function isNetworkFirst(request) {
+  const mode = request.mode;
+  if (mode === 'navigate') return true;             // page navigations
+  if (request.destination === 'document') return true;
+  if (request.url.includes('/api/')) return true;   // API + SSE
+  return false;
+}
 
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open(CACHE_NAME)
-      .then(cache => cache.addAll(urlsToCache))
+      .then(cache => cache.addAll(STATIC_ASSETS))
+      .then(() => self.skipWaiting())
+      .catch(err => console.warn('[sw] install error:', err))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys()
+      .then(keys => Promise.all(
+        keys
+          .filter(key => key !== CACHE_NAME)
+          .map(key => caches.delete(key))
+      ))
+      .then(() => self.clients.claim())
   );
 });
 
 self.addEventListener('fetch', event => {
+  const request = event.request;
+
+  // Never intercept non-GET requests (POST, PUT, etc.)
+  if (request.method !== 'GET') return;
+
+  // Network-first for navigations, documents, and API/SSE
+  if (isNetworkFirst(request)) {
+    event.respondWith(
+      fetch(request)
+        .then(response => {
+          // Cache successful navigations for offline fallback
+          if (response.ok && response.type === 'basic') {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(request, clone));
+          }
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+    return;
+  }
+
+  // Cache-first for static assets
   event.respondWith(
-    caches.match(event.request)
-      .then(response => response || fetch(event.request))
+    caches.match(request).then(response => response || fetch(request))
   );
 });
 


### PR DESCRIPTION
## Root cause

The service worker (`sw.js`) used a **cache-first strategy for all requests**, including navigations. It cached `/` and `/index.html` on install and served the cached version on every subsequent visit — **including the old CSP headers** (nonce-based `script-src`) that blocked inline scripts.

This is why the CSP fix in v0.4.15 didn't unblock the desktop web app: browsers with a cached service worker from a previous visit never got the updated HTML. The app stayed stuck on 'Connecting to OpenClaw Gateway' because inline scripts were still blocked by the stale CSP.

## Fix

- **Network-first for navigations, documents, and API/SSE** — browser always gets fresh HTML + headers from the server
- **Cache-first only for static assets** (favicons, manifest, etc.)
- **Bump cache name** `openclaw-chat-v1` → `openclaw-chat-v2` and purge old caches on activate
- `skipWaiting()` + `clients.claim()` so the new SW takes over immediately
- Add `controllerchange` listener in `index.html` to reload the page once the new service worker activates
- Remove `/` and `/index.html` from the pre-cache list — these are auth-gated and should not be cached at install time

## Verification

After merge + deploy:
1. Hard-refresh the page (Ctrl+Shift+R) to bypass any HTTP cache
2. The new service worker installs, purges the old cache, and takes control
3. The page reloads via `controllerchange` listener
4. The browser fetches fresh `index.html` with the corrected CSP headers
5. Inline scripts execute → app connects → status changes from 'Connecting…' to 'Connected'