### PR TITLE
fix: render-utils.js module not defined + Rocket Loader script conflict

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,15 +16,15 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="manifest" href="/manifest.json">
     <!-- OTA Update Manager -->
-    <script src="/mobile/update-manager.js"></script>
+    <script data-cfasync="false" src="/mobile/update-manager.js"></script>
     <!-- Extracted rendering utilities (shared with tests) -->
     <!-- Capacitor native-platform detection (shared across index.html and browser modules) -->
-    <script src="/lib/capacitor-detect.js"></script>
-    <script src="/lib/render-utils.js"></script>
+    <script data-cfasync="false" src="/lib/capacitor-detect.js"></script>
+    <script data-cfasync="false" src="/lib/render-utils.js"></script>
     <!-- Reaction event parsing (mirrors lib/reaction-events.js for browser) -->
-    <script src="/lib/reaction-events-browser.js"></script>
+    <script data-cfasync="false" src="/lib/reaction-events-browser.js"></script>
     <!-- Extracted API client & backend URL management -->
-    <script src="/lib/api-client.js"></script>
+    <script data-cfasync="false" src="/lib/api-client.js"></script>
     
     <style>
         :root {

--- a/public/lib/render-utils.js
+++ b/public/lib/render-utils.js
@@ -190,12 +190,14 @@ function decodeCopyPayload(payload) {
   }
 }
 
-module.exports = {
-  escapeHtml,
-  normalizedLang,
-  protectTokenMatches,
-  restoreTokenMatches,
-  highlightCode,
-  encodeCopyPayload,
-  decodeCopyPayload,
-};
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    escapeHtml,
+    normalizedLang,
+    protectTokenMatches,
+    restoreTokenMatches,
+    highlightCode,
+    encodeCopyPayload,
+    decodeCopyPayload,
+  };
+}


### PR DESCRIPTION
## Root cause

The console showed two errors that broke the app completely:

```
render-utils.js:193 Uncaught ReferenceError: module is not defined
VM159:1 Uncaught SyntaxError: Identifier 'API_BASE_STORAGE_KEY' has already been declared
``

**No `/api/` requests appeared in the Network tab** because the init IIFE never ran — `apiFetch` was undefined.

### Bug 1: `render-utils.js` — `module is not defined`

`render-utils.js` ended with a bare `module.exports = {...}` (no `typeof module` guard). In the browser, `module` doesn't exist → ReferenceError → script crashes. `api-client.js` already had the correct guard pattern; `render-utils.js` didn't.

### Bug 2: Cloudflare Rocket Loader — duplicate script execution

`rocket-loader.min.js` (Cloudflare Rocket Loader) was intercepting all `<script>` tags, deferring them, and re-executing them. This caused `api-client.js` to execute twice → `let API_BASE_STORAGE_KEY` redeclaration → SyntaxError → script dies → `apiFetch` never defined.

## Fix

1. **`render-utils.js`**: Wrap `module.exports` in `if (typeof module !== 'undefined' && module.exports)` (matches `api-client.js` pattern)
2. **`index.html`**: Add `data-cfasync="false"` to all external `<script>` tags — tells Rocket Loader to bypass them

## Verification

- All 281 tests pass
- `node --check` confirms no syntax errors
- After deploy: open DevTools Console — no more `module is not defined` or `API_BASE_STORAGE_KEY` errors. Network tab should show `/api/config`, `/api/sessions`, `/api/events` requests.