### PR TITLE
[codex] restore frontend startup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2031,7 +2031,6 @@
         let baseTitle = document.title;
         const sessionMetaByKey = new Map();
         const ASSISTANT_NAME_STORAGE_KEY = 'openclaw.assistantName';
-        const API_BASE_STORAGE_KEY = 'openclaw.apiBaseUrl';
         let configuredAssistantName = localStorage.getItem(ASSISTANT_NAME_STORAGE_KEY) || 'Assistant';
         let serviceWorkerRegistration = null;
         let notificationPermissionPrompted = false;

--- a/tests/browser-script-globals.test.js
+++ b/tests/browser-script-globals.test.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 const vm = require('node:vm');
 
 const publicDir = path.join(__dirname, '..', 'public');
+const publicRoot = path.resolve(publicDir);
 const indexHtml = fs.readFileSync(path.join(publicDir, 'index.html'), 'utf8');
 
 test('classic browser scripts share a valid global lexical scope', () => {
@@ -18,7 +19,11 @@ test('classic browser scripts share a valid global lexical scope', () => {
 
     const srcMatch = attributes.match(/\bsrc=["']([^"']+)["']/i);
     if (srcMatch) {
-      const sourcePath = path.join(publicDir, srcMatch[1].replace(/^\//, ''));
+      const sourcePath = path.resolve(publicRoot, srcMatch[1].replace(/^\//, ''));
+      assert.ok(
+        sourcePath.startsWith(`${publicRoot}${path.sep}`),
+        `script source must stay within public/: ${srcMatch[1]}`
+      );
       sources.push(fs.readFileSync(sourcePath, 'utf8'));
     } else {
       sources.push(match[2]);

--- a/tests/browser-script-globals.test.js
+++ b/tests/browser-script-globals.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const publicDir = path.join(__dirname, '..', 'public');
+const indexHtml = fs.readFileSync(path.join(publicDir, 'index.html'), 'utf8');
+
+test('classic browser scripts share a valid global lexical scope', () => {
+  const scriptPattern = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+  const sources = [];
+  let match;
+
+  while ((match = scriptPattern.exec(indexHtml)) !== null) {
+    const attributes = match[1];
+    if (/\btype=["']module["']/i.test(attributes)) continue;
+
+    const srcMatch = attributes.match(/\bsrc=["']([^"']+)["']/i);
+    if (srcMatch) {
+      const sourcePath = path.join(publicDir, srcMatch[1].replace(/^\//, ''));
+      sources.push(fs.readFileSync(sourcePath, 'utf8'));
+    } else {
+      sources.push(match[2]);
+    }
+  }
+
+  assert.ok(sources.length > 0, 'index.html should contain browser scripts');
+  assert.doesNotThrow(
+    () => new vm.Script(sources.join('\n;\n'), { filename: 'public/index.html scripts' }),
+    'classic scripts must not redeclare global let/const bindings'
+  );
+});


### PR DESCRIPTION
The 0.4.17 page never initialized because the inline app script redeclared `API_BASE_STORAGE_KEY` from `api-client.js`, so browsers rejected the script before any API calls ran. Remove the duplicate declaration and add a regression test that compiles all classic browser scripts in one shared lexical scope.

Validated with `npm test`, `npm run lint`, and a local browser startup smoke test.