### PR TITLE
[codex] restore shared session access

### DIFF
--- a/lib/session-auth.js
+++ b/lib/session-auth.js
@@ -1,121 +1,24 @@
 /**
- * Session/Operation Authorization Middleware
+ * Session access boundary.
  *
- * Ensures authenticated users can only access sessions they own.
- * Applied to routes that accept a sessionKey parameter.
- *
- * Ownership rules:
- * - When auth is disabled (authMode === 'none'): all access allowed (no-op).
- * - For local auth: the username from `req.user` must match the user portion
- *   of the session key (e.g., `agent:<username>:<thread>` matches user `<username>`).
- * - For OIDC: the user's email or preferred_username must appear in the session key.
- * - If no ownership match is found, returns 403 Forbidden.
+ * OpenClaw session keys use `agent:<agent-id>:<session-id>`. The agent ID is
+ * not a web username, and OpenClaw does not expose per-user ownership metadata.
+ * Miso Chat therefore authorizes session operations at the deployment boundary:
+ * every authenticated web user can access the same sessions returned by the
+ * authenticated `/api/sessions` endpoint.
  */
 
-/**
- * Extract the expected owner from a session key.
- * Handles formats like:
- *   agent:<username>:<thread>
- *   g-agent-<name>-<uuid>
- *   <any-other-key> (returns null — no known owner pattern)
- *
- * @param {string} sessionKey
- * @returns {string|null} - The inferred owner username, or null if unknown format.
- */
-function extractSessionOwner(sessionKey) {
-  if (!sessionKey || typeof sessionKey !== 'string') return null;
-
-  // Format: agent:<username>:<rest>
-  const agentMatch = sessionKey.match(/^agent:([^:]+):/);
-  if (agentMatch && agentMatch[1]) {
-    return agentMatch[1];
-  }
-
-  // Format: g-agent-<name>-<uuid> or similar g-agent patterns
-  const gAgentMatch = sessionKey.match(/^(?:g-agent-|g_agent-)([^-_.]+)/i);
-  if (gAgentMatch && gAgentMatch[1]) {
-    return gAgentMatch[1].toLowerCase();
-  }
-
-  return null;
-}
-
-/**
- * Check if the authenticated user owns (or has access to) a session.
- *
- * @param {object} req - Express request object with `user` populated by passport.
- * @param {string} sessionKey - The session key being accessed.
- * @param {string} authMode - One of 'none', 'local', 'oidc'.
- * @returns {boolean} - true if the user is authorized to access this session.
- */
-function checkSessionOwnership(req, sessionKey, authMode) {
-  // No auth mode: everything is accessible
+function checkSessionAccess(req, authMode) {
   if (authMode === 'none') return true;
-
-  // Must be authenticated
-  if (!req.user || !req.isAuthenticated?.()) return false;
-
-  const owner = extractSessionOwner(sessionKey);
-  if (!owner) {
-    // Unknown session key format — deny by default for safety.
-    // This catches any session key that doesn't follow the known patterns.
-    // In future, this could be relaxed if the Gateway provides explicit
-    // ownership metadata per session.
-    return false;
-  }
-
-  // Local auth: match username
-  if (authMode === 'local') {
-    const userIdentifier = String(req.user.username || '').toLowerCase().trim();
-    return userIdentifier === owner.toLowerCase();
-  }
-
-  // OIDC: match email or preferred_username against session key owner
-  if (authMode === 'oidc') {
-    const email = String(req.user.email || '').toLowerCase().trim();
-    const username = String(req.user.username || '').toLowerCase().trim();
-    return (
-      email.includes(owner.toLowerCase()) ||
-      username === owner.toLowerCase()
-    );
-  }
-
-  // Unknown auth mode: deny by default
-  return false;
+  if (authMode !== 'local' && authMode !== 'oidc') return false;
+  return Boolean(req.user && req.isAuthenticated?.());
 }
 
-/**
- * Express middleware factory for session authorization.
- *
- * Usage:
- *   app.get('/api/sessions/:key/history',
- *     isAuthenticated,
- *     requireSessionOwnership(authMode),
- *     handler
- *   );
- *
- * @param {string} authMode - The current auth mode from server.js.
- * @returns {function} Express middleware function.
- */
-function requireSessionOwnership(authMode) {
-  return function sessionOwnershipMiddleware(req, res, next) {
-    // Extract session key from URL params or query/body
-    let sessionKey = null;
-
-    if (req.params && req.params.key) {
-      sessionKey = String(req.params.key).trim();
-    } else if (req.query && typeof req.query.sessionKey === 'string') {
-      sessionKey = req.query.sessionKey.trim();
-    } else if (req.body && typeof req.body.sessionKey === 'string') {
-      sessionKey = req.body.sessionKey.trim();
-    }
-
-    // If no session key is provided, skip authorization (route doesn't target a specific session)
-    if (!sessionKey) return next();
-
-    if (!checkSessionOwnership(req, sessionKey, authMode)) {
+function requireSessionAccess(authMode) {
+  return function sessionAccessMiddleware(req, res, next) {
+    if (!checkSessionAccess(req, authMode)) {
       return res.status(403).json({
-        error: 'Forbidden: you do not have access to this session',
+        error: 'Forbidden: authenticated session access required',
       });
     }
 
@@ -123,4 +26,4 @@ function requireSessionOwnership(authMode) {
   };
 }
 
-module.exports = { checkSessionOwnership, requireSessionOwnership, extractSessionOwner };
+module.exports = { checkSessionAccess, requireSessionAccess };

--- a/public/index.html
+++ b/public/index.html
@@ -3684,11 +3684,13 @@
                 const data = await response.json();
 
                 if (!response.ok || !data?.success) {
-                    sendFailed = true;
                     const errorText = data?.error || response.statusText || 'Send failed';
                     addMessage('system', errorText);
-                    sendQueue.unshift(next);
-                    savePendingQueue(sendQueue);
+                    if (isRetryableSendStatus(response.status)) {
+                        sendFailed = true;
+                        sendQueue.unshift(next);
+                        savePendingQueue(sendQueue);
+                    }
                     return;
                 }
 

--- a/public/lib/api-client.js
+++ b/public/lib/api-client.js
@@ -227,6 +227,15 @@ async function apiFetch(path, options) {
     return response;
 }
 
+/**
+ * Only transient HTTP failures should remain in the persistent send queue.
+ * Permanent client errors must be shown once and discarded instead of retried.
+ */
+function isRetryableSendStatus(status) {
+    const code = Number(status);
+    return code === 408 || code === 425 || code === 429 || code >= 500;
+}
+
 /* ---------------------------------------------------------------------------
  * Backend connection testing
  * ------------------------------------------------------------------------ */
@@ -288,6 +297,7 @@ if (typeof module !== 'undefined' && module.exports) {
         API_BASE_STORAGE_KEY,
         normalizeBaseUrl,
         apiUrl,
+        isRetryableSendStatus,
         backendHealthUrl,
         testBackendConnection,
     };

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ require('dotenv').config();
 const { GatewayWsManager } = require('./lib/gateway-ws');
 const securityMiddleware = require('./security');
 const { reactions } = require('./lib/db');
-const { requireSessionOwnership } = require('./lib/session-auth');
+const { requireSessionAccess } = require('./lib/session-auth');
 const { parseGatewayReactionEvent } = require('./lib/reaction-events');
 
 const { isForbiddenLinkPreviewHost, hostResolvesToPrivate, resolveHostToIps, isPrivateIPv4, isPrivateIPv6 } = require('./lib/ssrf-validation');
@@ -813,7 +813,7 @@ app.get('/api/sessions', isAuthenticated, async (req, res) => {
   }
 });
 
-app.get('/api/sessions/:key/history', isAuthenticated, requireSessionOwnership(authMode), async (req, res) => {
+app.get('/api/sessions/:key/history', isAuthenticated, requireSessionAccess(authMode), async (req, res) => {
   try {
     const sessionKey = String(req.params.key || '').trim();
     if (!sessionKey) {
@@ -865,7 +865,7 @@ app.get('/api/sessions/:key/history', isAuthenticated, requireSessionOwnership(a
   }
 });
 
-app.post('/api/sessions/:key/send', isAuthenticated, requireSessionOwnership(authMode), async (req, res) => {
+app.post('/api/sessions/:key/send', isAuthenticated, requireSessionAccess(authMode), async (req, res) => {
   try {
     const sessionKey = String(req.params.key || '').trim();
     const text = String(req.body?.text || req.body?.message || '').trim();
@@ -906,7 +906,7 @@ app.post('/api/sessions/:key/send', isAuthenticated, requireSessionOwnership(aut
   }
 });
 
-app.post('/api/sessions/:key/send-stream', isAuthenticated, requireSessionOwnership(authMode), async (req, res) => {
+app.post('/api/sessions/:key/send-stream', isAuthenticated, requireSessionAccess(authMode), async (req, res) => {
   try {
     const sessionKey = String(req.params.key || '').trim();
     const text = String(req.body?.text || req.body?.message || '').trim();
@@ -1167,7 +1167,7 @@ async function _fetchLinkPreview(rawUrl, targetUrl) {
 }
 
 // GET /api/openclaw-status - Return native OpenClaw session status card/details
-app.get('/api/openclaw-status', isAuthenticated, requireSessionOwnership(authMode), async (req, res) => {
+app.get('/api/openclaw-status', isAuthenticated, requireSessionAccess(authMode), async (req, res) => {
   try {
     const sessionKey = typeof req.query.sessionKey === 'string' && req.query.sessionKey.trim()
       ? req.query.sessionKey.trim()
@@ -1193,7 +1193,7 @@ app.get('/api/openclaw-status', isAuthenticated, requireSessionOwnership(authMod
 });
 
 // POST /api/openclaw-stop - Abort current OpenClaw chat run for a session
-app.post('/api/openclaw-stop', isAuthenticated, requireSessionOwnership(authMode), async (req, res) => {
+app.post('/api/openclaw-stop', isAuthenticated, requireSessionAccess(authMode), async (req, res) => {
   try {
     const sessionKey = typeof req.body?.sessionKey === 'string' && req.body.sessionKey.trim()
       ? req.body.sessionKey.trim()
@@ -1318,7 +1318,7 @@ function inferAgentNameFromKey(sessionKey) {
 // ============ REACTION API ENDPOINTS ============
 
 // GET /api/reactions/:sessionKey - Get all reactions for a session (batch load)
-app.get('/api/reactions/:sessionKey', isAuthenticated, requireSessionOwnership(authMode), (req, res) => {
+app.get('/api/reactions/:sessionKey', isAuthenticated, requireSessionAccess(authMode), (req, res) => {
   try {
     const { sessionKey } = req.params;
     const allReactions = reactions.getForSession(sessionKey);
@@ -1330,7 +1330,7 @@ app.get('/api/reactions/:sessionKey', isAuthenticated, requireSessionOwnership(a
 });
 
 // GET /api/messages/:messageId/reactions - Get reactions for a specific message
-app.get('/api/messages/:messageId/reactions', isAuthenticated, requireSessionOwnership(authMode), (req, res) => {
+app.get('/api/messages/:messageId/reactions', isAuthenticated, requireSessionAccess(authMode), (req, res) => {
   try {
     const { messageId } = req.params;
     const sessionKey = typeof req.query?.sessionKey === 'string' ? req.query.sessionKey : null;
@@ -1343,7 +1343,7 @@ app.get('/api/messages/:messageId/reactions', isAuthenticated, requireSessionOwn
 });
 
 // POST /api/messages/:messageId/reactions - Add or remove a reaction (toggle)
-app.post('/api/messages/:messageId/reactions', isAuthenticated, requireSessionOwnership(authMode), (req, res) => {
+app.post('/api/messages/:messageId/reactions', isAuthenticated, requireSessionAccess(authMode), (req, res) => {
   try {
     const { messageId } = req.params;
     const { emoji, sessionKey } = req.body;

--- a/tests/api-client.test.js
+++ b/tests/api-client.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { isRetryableSendStatus } = require('../public/lib/api-client');
+
+test('send queue retries only transient HTTP failures', () => {
+  for (const status of [408, 425, 429, 500, 502, 503]) {
+    assert.equal(isRetryableSendStatus(status), true, `${status} should be retryable`);
+  }
+
+  for (const status of [0, 400, 401, 403, 404, 409, 422]) {
+    assert.equal(isRetryableSendStatus(status), false, `${status} should not be retryable`);
+  }
+});

--- a/tests/authz-integration.test.js
+++ b/tests/authz-integration.test.js
@@ -1,12 +1,9 @@
 /**
  * Authorization / Integration Test Matrix
  *
- * Covers the audit findings for misospace/miso-chat#539:
- *   1. Authenticated users are not authorized per gateway session or operation.
- *      Only `isAuthenticated` is the gate — missing `requireSessionOwnership` on
- *      some routes. This test matrix verifies that all authenticated routes properly
- *      enforce session ownership, denial of cross-user access, and correct behavior
- *      under OIDC vs local auth modes.
+ * Covers the authentication and request-origin boundaries:
+ *   1. Session routes require a valid web login. OpenClaw session keys identify
+ *      agents, not web users, so authenticated users share deployment access.
  *   2. CSRF protection is origin-only and broad for mobile/web hybrid deployment.
  *      Verifies csrfOriginCheck blocks untrusted origins and accepts trusted ones.
  *   3. `/api/config` exposure — verifies what config is publicly accessible.
@@ -117,20 +114,15 @@ test('GET /api/config exposes defaultSessionKey even without auth', async () => 
 });
 
 test('GET /api/config does NOT expose OIDC secrets when OIDC is enabled', async () => {
-  // Note: We cannot start the server with AUTH_MODE=oidc without proper OIDC config
-  // (issuer, clientID, etc.), so we verify via lib-level assertions instead.
-  const { checkSessionOwnership } = require('../lib/session-auth');
-
-  // OIDC auth mode requires authentication — no unauthenticated access
-  const unauthReq = { user: null, isAuthenticated: () => false };
-  assert.equal(checkSessionOwnership(unauthReq, 'agent:anyone:any', 'oidc'), false);
-
-  // OIDC mode grants access only when email/username matches session owner
-  const oidcMatch = { user: { username: 'alice', email: 'alice@example.com' }, isAuthenticated: () => true };
-  assert.equal(checkSessionOwnership(oidcMatch, 'agent:alice:main', 'oidc'), true);
-
-  const oidcNoMatch = { user: { username: 'bob', email: 'bob@example.com' }, isAuthenticated: () => true };
-  assert.equal(checkSessionOwnership(oidcNoMatch, 'agent:alice:main', 'oidc'), false);
+  await withServer({
+    AUTH_MODE: 'none',
+    OIDC_CLIENT_SECRET: 'must-not-leak',
+    OIDC_CLIENT_ID: 'miso-chat',
+  }, async (base) => {
+    const res = await httpReq(base, '/api/config');
+    assert.equal(res.statusCode, 200);
+    assert.doesNotMatch(JSON.stringify(res.json), /must-not-leak/);
+  });
 });
 
 // ============================================================
@@ -275,8 +267,8 @@ test('POST /api/messages/:messageId/reactions returns redirect or error when una
 // SECTION 4: Session ownership middleware verification via route behavior
 // ============================================================
 
-test('requireSessionOwnership middleware blocks cross-user session access', async () => {
-  const { requireSessionOwnership, checkSessionOwnership } = require('../lib/session-auth');
+test('session access does not infer web ownership from an OpenClaw agent ID', async () => {
+  const { requireSessionAccess } = require('../lib/session-auth');
 
   // Simulate Alice trying to access Bob's session in local auth mode
   const req = {
@@ -297,16 +289,14 @@ test('requireSessionOwnership middleware blocks cross-user session access', asyn
   };
 
   let nextCalled = false;
-  const mw = requireSessionOwnership('local');
+  const mw = requireSessionAccess('local');
   mw(req, res, () => { nextCalled = true; });
 
-  assert.equal(nextCalled, false, 'Cross-user session access should be blocked');
-  assert.equal(res.statusCode, 403);
-  assert.ok(res.payload.error.includes('Forbidden'), 'Should return Forbidden error');
+  assert.equal(nextCalled, true, 'Authenticated users share deployment session access');
 });
 
-test('requireSessionOwnership middleware allows same-user session access', async () => {
-  const { requireSessionOwnership } = require('../lib/session-auth');
+test('requireSessionAccess allows an authenticated local user', async () => {
+  const { requireSessionAccess } = require('../lib/session-auth');
 
   // Alice accessing her own session
   const req = {
@@ -327,14 +317,14 @@ test('requireSessionOwnership middleware allows same-user session access', async
   };
 
   let nextCalled = false;
-  const mw = requireSessionOwnership('local');
+  const mw = requireSessionAccess('local');
   mw(req, res, () => { nextCalled = true; });
 
   assert.equal(nextCalled, true, 'Same-user session access should be allowed');
 });
 
-test('requireSessionOwnership middleware allows access when authMode=none', async () => {
-  const { requireSessionOwnership } = require('../lib/session-auth');
+test('requireSessionAccess allows access when authMode=none', async () => {
+  const { requireSessionAccess } = require('../lib/session-auth');
 
   // Any user accessing any session when auth is disabled
   const req = {
@@ -355,14 +345,14 @@ test('requireSessionOwnership middleware allows access when authMode=none', asyn
   };
 
   let nextCalled = false;
-  const mw = requireSessionOwnership('none');
+  const mw = requireSessionAccess('none');
   mw(req, res, () => { nextCalled = true; });
 
   assert.equal(nextCalled, true, 'Auth disabled mode should allow all access');
 });
 
-test('requireSessionOwnership middleware checks query sessionKey parameter', async () => {
-  const { requireSessionOwnership } = require('../lib/session-auth');
+test('session access does not treat query sessionKey as web ownership data', async () => {
+  const { requireSessionAccess } = require('../lib/session-auth');
 
   // Bob accessing Alice's session via query param
   const req = {
@@ -383,14 +373,14 @@ test('requireSessionOwnership middleware checks query sessionKey parameter', asy
   };
 
   let nextCalled = false;
-  const mw = requireSessionOwnership('local');
+  const mw = requireSessionAccess('local');
   mw(req, res, () => { nextCalled = true; });
 
-  assert.equal(nextCalled, false, 'Cross-user access via query param should be blocked');
+  assert.equal(nextCalled, true, 'Authenticated users share deployment session access');
 });
 
-test('requireSessionOwnership middleware checks body sessionKey parameter', async () => {
-  const { requireSessionOwnership } = require('../lib/session-auth');
+test('session access does not treat body sessionKey as web ownership data', async () => {
+  const { requireSessionAccess } = require('../lib/session-auth');
 
   // Bob accessing Alice's session via body param
   const req = {
@@ -411,14 +401,14 @@ test('requireSessionOwnership middleware checks body sessionKey parameter', asyn
   };
 
   let nextCalled = false;
-  const mw = requireSessionOwnership('local');
+  const mw = requireSessionAccess('local');
   mw(req, res, () => { nextCalled = true; });
 
-  assert.equal(nextCalled, false, 'Cross-user access via body param should be blocked');
+  assert.equal(nextCalled, true, 'Authenticated users share deployment session access');
 });
 
-test('requireSessionOwnership middleware skips when no session key provided', async () => {
-  const { requireSessionOwnership } = require('../lib/session-auth');
+test('requireSessionAccess does not require a session key', async () => {
+  const { requireSessionAccess } = require('../lib/session-auth');
 
   // Route without session key (e.g., /api/sessions list)
   const req = {
@@ -439,111 +429,111 @@ test('requireSessionOwnership middleware skips when no session key provided', as
   };
 
   let nextCalled = false;
-  const mw = requireSessionOwnership('local');
+  const mw = requireSessionAccess('local');
   mw(req, res, () => { nextCalled = true; });
 
   assert.equal(nextCalled, true, 'Routes without session key should skip ownership check');
 });
 
 // ============================================================
-// SECTION 5: OIDC mode — session ownership by email/username
+// SECTION 5: OIDC session access
 // ============================================================
 
-test('checkSessionOwnership allows OIDC user when email includes session owner', async () => {
-  const { checkSessionOwnership } = require('../lib/session-auth');
+test('checkSessionAccess allows an authenticated OIDC user with email', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const req = {
     user: { username: 'user123', email: 'alice@example.com' },
     isAuthenticated: () => true,
   };
-  assert.equal(checkSessionOwnership(req, 'agent:alice:main', 'oidc'), true);
+  assert.equal(checkSessionAccess(req, 'oidc'), true);
 });
 
-test('checkSessionOwnership allows OIDC user when username matches session owner', async () => {
-  const checkSessionOwnership = require('../lib/session-auth').checkSessionOwnership;
+test('checkSessionAccess allows an authenticated OIDC user with username', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const req = {
     user: { username: 'alice', email: 'alice@example.com' },
     isAuthenticated: () => true,
   };
-  assert.equal(checkSessionOwnership(req, 'agent:alice:main', 'oidc'), true);
+  assert.equal(checkSessionAccess(req, 'oidc'), true);
 });
 
-test('checkSessionOwnership denies OIDC user when neither email nor username matches', async () => {
-  const { checkSessionOwnership } = require('../lib/session-auth');
+test('session access allows an authenticated OIDC user regardless of agent ID', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const req = {
     user: { username: 'bob', email: 'bob@example.com' },
     isAuthenticated: () => true,
   };
-  assert.equal(checkSessionOwnership(req, 'agent:alice:main', 'oidc'), false);
+  assert.equal(checkSessionAccess(req, 'oidc'), true);
 });
 
-test('checkSessionOwnership denies unauthenticated requests in OIDC mode', async () => {
-  const { checkSessionOwnership } = require('../lib/session-auth');
+test('checkSessionAccess denies unauthenticated requests in OIDC mode', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const req = { user: null, isAuthenticated: () => false };
-  assert.equal(checkSessionOwnership(req, 'agent:bob:main', 'oidc'), false);
+  assert.equal(checkSessionAccess(req, 'oidc'), false);
 });
 
-test('checkSessionOwnership denies unknown session key format in OIDC mode', async () => {
-  const { checkSessionOwnership } = require('../lib/session-auth');
+test('session access does not parse unknown session keys in OIDC mode', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const req = {
     user: { username: 'alice', email: 'alice@example.com' },
     isAuthenticated: () => true,
   };
-  assert.equal(checkSessionOwnership(req, 'unknown-session-key', 'oidc'), false);
+  assert.equal(checkSessionAccess(req, 'oidc'), true);
 });
 
 // ============================================================
-// SECTION 6: Local auth mode — session ownership by username
+// SECTION 6: Local session access
 // ============================================================
 
-test('checkSessionOwnership allows local user when username matches session owner', async () => {
-  const { checkSessionOwnership } = require('../lib/session-auth');
+test('checkSessionAccess allows an authenticated local user', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const req = { user: { username: 'alice' }, isAuthenticated: () => true };
-  assert.equal(checkSessionOwnership(req, 'agent:alice:main', 'local'), true);
+  assert.equal(checkSessionAccess(req, 'local'), true);
 });
 
-test('checkSessionOwnership denies local user when username does not match session owner', async () => {
-  const { checkSessionOwnership } = require('../lib/session-auth');
+test('session access allows an authenticated local user regardless of agent ID', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const req = { user: { username: 'bob' }, isAuthenticated: () => true };
-  assert.equal(checkSessionOwnership(req, 'agent:alice:main', 'local'), false);
+  assert.equal(checkSessionAccess(req, 'local'), true);
 });
 
-test('checkSessionOwnership denies unauthenticated requests in local mode', async () => {
-  const { checkSessionOwnership } = require('../lib/session-auth');
+test('checkSessionAccess denies unauthenticated requests in local mode', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const req = { user: null, isAuthenticated: () => false };
-  assert.equal(checkSessionOwnership(req, 'agent:bob:main', 'local'), false);
+  assert.equal(checkSessionAccess(req, 'local'), false);
 });
 
-test('checkSessionOwnership denies unknown session key format in local mode', async () => {
-  const { checkSessionOwnership } = require('../lib/session-auth');
+test('session access does not parse unknown session keys in local mode', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const req = { user: { username: 'alice' }, isAuthenticated: () => true };
-  assert.equal(checkSessionOwnership(req, 'random-key-123', 'local'), false);
+  assert.equal(checkSessionAccess(req, 'local'), true);
 });
 
 // ============================================================
 // SECTION 7: g-agent session key format ownership
 // ============================================================
 
-test('checkSessionOwnership allows matching g-agent session key in local mode', async () => {
-  const { checkSessionOwnership } = require('../lib/session-auth');
+test('checkSessionAccess allows authenticated local access to g-agent sessions', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const req = { user: { username: 'chat' }, isAuthenticated: () => true };
-  assert.equal(checkSessionOwnership(req, 'g-agent-chat-123e4567-e89b-12d3-a456-426614174000', 'local'), true);
+  assert.equal(checkSessionAccess(req, 'local'), true);
 });
 
-test('checkSessionOwnership denies non-matching g-agent session key in local mode', async () => {
-  const { checkSessionOwnership } = require('../lib/session-auth');
+test('session access allows authenticated users across g-agent IDs', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const req = { user: { username: 'alice' }, isAuthenticated: () => true };
-  assert.equal(checkSessionOwnership(req, 'g-agent-chat-123e4567-e89b-12d3-a456-426614174000', 'local'), false);
+  assert.equal(checkSessionAccess(req, 'local'), true);
 });
 
 // ============================================================
@@ -559,19 +549,18 @@ test('When AUTH_MODE=none, /api/config is accessible without auth', async () => 
   });
 });
 
-test('When AUTH_MODE=none, session ownership check is a no-op', async () => {
-  const { checkSessionOwnership } = require('../lib/session-auth');
+test('When AUTH_MODE=none, session access check is a no-op', async () => {
+  const { checkSessionAccess } = require('../lib/session-auth');
 
   const fakeReq = { user: null, isAuthenticated: () => false };
-  assert.equal(checkSessionOwnership(fakeReq, 'agent:anyone:any', 'none'), true);
-  assert.equal(checkSessionOwnership(fakeReq, 'unknown-key', 'none'), true);
+  assert.equal(checkSessionAccess(fakeReq, 'none'), true);
 });
 
 // ============================================================
-// SECTION 9: Routes that SHOULD have but might lack requireSessionOwnership
+// SECTION 9: Session routes require authentication
 // ============================================================
 
-test('GET /api/sessions/:key/history enforces session ownership (route-level check)', async () => {
+test('GET /api/sessions/:key/history requires authentication', async () => {
   await withServer({ AUTH_MODE: 'local', LOCAL_USERS: 'alice:password' }, async (base) => {
     const res = await httpReq(base, '/api/sessions/agent:bob:main/history');
     // Without auth cookie, should NOT return 200 with history data
@@ -579,7 +568,7 @@ test('GET /api/sessions/:key/history enforces session ownership (route-level che
   });
 });
 
-test('GET /api/sessions/:key/send enforces session ownership (route-level check)', async () => {
+test('GET /api/sessions/:key/send requires authentication', async () => {
   await withServer({ AUTH_MODE: 'local', LOCAL_USERS: 'alice:password' }, async (base) => {
     const res = await httpReq(base, '/api/sessions/agent:bob:main/send', {
       method: 'POST',
@@ -591,7 +580,7 @@ test('GET /api/sessions/:key/send enforces session ownership (route-level check)
   });
 });
 
-test('GET /api/sessions/:key/send-stream enforces session ownership (route-level check)', async () => {
+test('GET /api/sessions/:key/send-stream requires authentication', async () => {
   await withServer({ AUTH_MODE: 'local', LOCAL_USERS: 'alice:password' }, async (base) => {
     const res = await httpReq(base, '/api/sessions/agent:bob:main/send-stream', {
       method: 'POST',

--- a/tests/session-auth.test.js
+++ b/tests/session-auth.test.js
@@ -1,180 +1,65 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { checkSessionOwnership, requireSessionOwnership, extractSessionOwner } = require('../lib/session-auth');
+const { checkSessionAccess, requireSessionAccess } = require('../lib/session-auth');
 
-// ===== extractSessionOwner tests =====
-
-test('extractSessionOwner parses agent:<username>:<thread> format', () => {
-  assert.equal(extractSessionOwner('agent:admin:main'), 'admin');
-  assert.equal(extractSessionOwner('agent:alice:thread-123'), 'alice');
-  assert.equal(extractSessionOwner('agent:bob:chat:gpt-4o-thread-abc'), 'bob');
-});
-
-test('extractSessionOwner parses g-agent-<name>-<uuid> format', () => {
-  assert.equal(extractSessionOwner('g-agent-chat-123e4567-e89b-12d3-a456-426614174000'), 'chat');
-  assert.equal(extractSessionOwner('g_agent-asistent-123e4567-e89b-12d3-a456-426614174000'), 'asistent');
-});
-
-test('extractSessionOwner returns null for unknown formats', () => {
-  assert.equal(extractSessionOwner('unknown-key'), null);
-  assert.equal(extractSessionOwner(''), null);
-  assert.equal(extractSessionOwner(null), null);
-  assert.equal(extractSessionOwner(undefined), null);
-  assert.equal(extractSessionOwner('agent:main:main'), 'main'); // edge case: single-part after agent:
-});
-
-// ===== checkSessionOwnership tests =====
-
-function makeUser(username, email) {
-  const user = { username };
-  if (email) user.email = email;
-  return user;
-}
-
-function makeRequest(user) {
+function makeRequest(authenticated = true) {
   return {
-    user,
-    isAuthenticated: () => true,
+    user: authenticated ? { username: 'web-user' } : null,
+    isAuthenticated: () => authenticated,
   };
 }
 
-test('checkSessionOwnership allows access when authMode is none', () => {
-  const req = makeRequest(makeUser('anyone'));
-  assert.equal(checkSessionOwnership(req, 'agent:admin:main', 'none'), true);
-  assert.equal(checkSessionOwnership(req, 'unknown-key', 'none'), true);
+test('authenticated users can access OpenClaw agent sessions', () => {
+  const req = makeRequest();
+
+  assert.equal(checkSessionAccess(req, 'local'), true);
+  assert.equal(checkSessionAccess(req, 'oidc'), true);
 });
 
-test('checkSessionOwnership denies unauthenticated requests', () => {
-  const req = { user: null, isAuthenticated: () => false };
-  assert.equal(checkSessionOwnership(req, 'agent:admin:main', 'local'), false);
+test('session access does not treat the OpenClaw agent ID as a username', () => {
+  const req = makeRequest();
+
+  assert.equal(checkSessionAccess(req, 'oidc'), true);
 });
 
-test('checkSessionOwnership allows matching local auth user', () => {
-  const req = makeRequest(makeUser('admin'));
-  assert.equal(checkSessionOwnership(req, 'agent:admin:main', 'local'), true);
-  assert.equal(checkSessionOwnership(req, 'agent:alice:thread-1', 'local'), false);
+test('session access rejects unauthenticated users when auth is enabled', () => {
+  const req = makeRequest(false);
+
+  assert.equal(checkSessionAccess(req, 'local'), false);
+  assert.equal(checkSessionAccess(req, 'oidc'), false);
 });
 
-test('checkSessionOwnership allows matching OIDC user by username', () => {
-  const req = makeRequest(makeUser('alice', 'alice@example.com'));
-  assert.equal(checkSessionOwnership(req, 'agent:alice:main', 'oidc'), true);
-  assert.equal(checkSessionOwnership(req, 'agent:bob:main', 'oidc'), false);
+test('session access allows auth-disabled deployments', () => {
+  assert.equal(checkSessionAccess(makeRequest(false), 'none'), true);
 });
 
-test('checkSessionOwnership allows matching OIDC user by email substring', () => {
-  const req = makeRequest(makeUser('user123', 'alice@example.com'));
-  // email contains owner name
-  assert.equal(checkSessionOwnership(req, 'agent:alice:main', 'oidc'), true);
+test('session access denies unknown auth modes', () => {
+  assert.equal(checkSessionAccess(makeRequest(), 'unexpected'), false);
 });
 
-test('checkSessionOwnership denies unknown session key format', () => {
-  const req = makeRequest(makeUser('admin'));
-  assert.equal(checkSessionOwnership(req, 'unknown-session-key', 'local'), false);
-  assert.equal(checkSessionOwnership(req, 'unknown-session-key', 'oidc'), false);
+test('requireSessionAccess allows an authenticated request', () => {
+  const middleware = requireSessionAccess('oidc');
+  let nextCalled = false;
+
+  middleware(makeRequest(), {}, () => { nextCalled = true; });
+
+  assert.equal(nextCalled, true);
 });
 
-// ===== requireSessionOwnership middleware tests =====
-
-function createReq(params, body, query) {
-  return {
-    params: params || {},
-    body: body || {},
-    query: query || {},
-    user: makeUser('admin'),
-    isAuthenticated: () => true,
-  };
-}
-
-function createResMock() {
+test('requireSessionAccess blocks an unauthenticated request', () => {
+  const middleware = requireSessionAccess('oidc');
   const res = {
     statusCode: 200,
-    payload: undefined,
-    headers: {},
-    setHeader(name, value) { this.headers[name] = value; },
+    payload: null,
     status(code) { this.statusCode = code; return this; },
     json(payload) { this.payload = payload; return this; },
   };
-  return res;
-}
-
-test('requireSessionOwnership middleware blocks unauthorized access', () => {
-  const mw = requireSessionOwnership('local');
-  const req = createReq({ key: 'agent:bob:main' });
-  const res = createResMock();
   let nextCalled = false;
 
-  mw(req, res, () => { nextCalled = true; });
+  middleware(makeRequest(false), res, () => { nextCalled = true; });
 
   assert.equal(nextCalled, false);
   assert.equal(res.statusCode, 403);
-  assert.ok(res.payload.error.includes('Forbidden'));
-});
-
-test('requireSessionOwnership middleware allows authorized access', () => {
-  const mw = requireSessionOwnership('local');
-  const req = createReq({ key: 'agent:admin:main' });
-  const res = createResMock();
-  let nextCalled = false;
-
-  mw(req, res, () => { nextCalled = true; });
-
-  assert.equal(nextCalled, true);
-});
-
-test('requireSessionOwnership middleware skips when no session key', () => {
-  const mw = requireSessionOwnership('local');
-  const req = createReq({});
-  const res = createResMock();
-  let nextCalled = false;
-
-  mw(req, res, () => { nextCalled = true; });
-
-  assert.equal(nextCalled, true);
-});
-
-test('requireSessionOwnership middleware checks query sessionKey', () => {
-  const mw = requireSessionOwnership('local');
-  const req = createReq({}, {}, { sessionKey: 'agent:bob:main' });
-  const res = createResMock();
-  let nextCalled = false;
-
-  mw(req, res, () => { nextCalled = true; });
-
-  assert.equal(nextCalled, false);
-});
-
-test('requireSessionOwnership middleware checks body sessionKey', () => {
-  const mw = requireSessionOwnership('local');
-  const req = createReq({}, { sessionKey: 'agent:bob:main' });
-  const res = createResMock();
-  let nextCalled = false;
-
-  mw(req, res, () => { nextCalled = true; });
-
-  assert.equal(nextCalled, false);
-});
-
-test('requireSessionOwnership middleware allows OIDC user by email', () => {
-  const req = createReq({ key: 'agent:alice:main' });
-  req.user = makeUser('user123', 'alice@example.com');
-  const mw = requireSessionOwnership('oidc');
-  const res = createResMock();
-  let nextCalled = false;
-
-  mw(req, res, () => { nextCalled = true; });
-
-  assert.equal(nextCalled, true);
-});
-
-test('requireSessionOwnership middleware denies OIDC user without match', () => {
-  const req = createReq({ key: 'agent:bob:main' });
-  req.user = makeUser('alice', 'alice@example.com');
-  const mw = requireSessionOwnership('oidc');
-  const res = createResMock();
-  let nextCalled = false;
-
-  mw(req, res, () => { nextCalled = true; });
-
-  assert.equal(nextCalled, false);
+  assert.match(res.payload.error, /authenticated session access required/i);
 });


### PR DESCRIPTION
Live `0.4.18` treated the OpenClaw agent ID in `agent:main:main` as a web username, so authenticated history and send requests returned `403`; the persistent send queue retried that permanent failure until it became `429`. Keep authentication as the deployment access boundary, stop inferring user ownership from OpenClaw session keys, and retry only transient send failures.

Validated against the live browser/cluster failure, plus `npm test` and `npm run lint`.