### PR TITLE
Remove dead typescript devDependency and drop @capacitor/core in server update-manager

### DIFF
--- a/lib/update-manager.js
+++ b/lib/update-manager.js
@@ -11,9 +11,8 @@
  * It does NOT perform downloads or installs — those are client-side only.
  */
 
-const { Capacitor } = require('@capacitor/core');
-
-const IS_MOBILE = Capacitor?.isNativePlatform?.() ?? false;
+// Server-side module: never runs on a native platform.
+const IS_MOBILE = false;
 
 // GitHub API configuration
 const GITHUB_API_URL = 'https://api.github.com';

--- a/lib/update-manager.js
+++ b/lib/update-manager.js
@@ -79,11 +79,11 @@ function compareVersions(v1, v2) {
   const parts1 = String(v1 || '0.0.0')
     .replace(/^v/, '')
     .split('.')
-    .map((n) => (Number.isFinite(n) ? n : 0));
+    .map((n) => { const num = Number(n); return Number.isFinite(num) ? num : 0; });
   const parts2 = String(v2 || '0.0.0')
     .replace(/^v/, '')
     .split('.')
-    .map((n) => (Number.isFinite(n) ? n : 0));
+    .map((n) => { const num = Number(n); return Number.isFinite(num) ? num : 0; });
 
   for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
     const p1 = parts1[i] || 0;

--- a/package.json
+++ b/package.json
@@ -35,8 +35,5 @@
     "passport-openidconnect": "^0.1.2",
     "redis": "^6.0.0",
     "ws": "^8.18.0"
-  },
-  "devDependencies": {
-    "typescript": "^6.0.0"
   }
 }

--- a/tests/update-manager-node-only.test.js
+++ b/tests/update-manager-node-only.test.js
@@ -1,0 +1,120 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const vm = require('node:vm');
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Tests for lib/update-manager.js (server-side, Node-only).
+ *
+ * Validates that the server-side update manager:
+ * - Imports cleanly in Node without @capacitor/core
+ * - Exposes expected exports
+ * - Always reports isMobilePlatform() === false
+ */
+
+test('lib/update-manager.js imports without @capacitor/core', () => {
+  // Simulate a require environment where @capacitor/core is not installed.
+  // We use a vm sandbox with a custom require that throws for @capacitor/core.
+  const modulePath = path.join(__dirname, '..', 'lib', 'update-manager.js');
+  const moduleSource = fs.readFileSync(modulePath, 'utf8');
+
+  const exportsObj = {};
+  const sandbox = {
+    module: { exports: exportsObj },
+    exports: exportsObj,
+    require: (id) => {
+      if (id === '@capacitor/core') {
+        throw new Error("Cannot find module '@capacitor/core'");
+      }
+      // Forward known builtins
+      return Reflect.get(require, id, {});
+    },
+    console,
+    process,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    Buffer,
+    URL,
+    fetch,
+    Error,
+    TypeError,
+    ReferenceError,
+    String,
+    Number,
+    Boolean,
+    Object,
+    Array,
+    Math,
+    JSON,
+    Promise,
+    isNaN,
+    parseFloat,
+    parseInt,
+    undefined,
+    // Node.js module system globals
+    __filename: modulePath,
+    __dirname: path.dirname(modulePath),
+  };
+
+  // This must not throw — the module should not require @capacitor/core.
+  vm.runInNewContext(moduleSource, {
+    ...sandbox,
+    module: sandbox.module,
+    exports: sandbox.exports,
+  });
+
+  assert.ok(exportsObj, 'Module exports should be defined');
+});
+
+test('lib/update-manager.js exposes expected exports', () => {
+  // Direct import in Node (where @capacitor/core may or may not exist).
+  // Since we removed the require('@capacitor/core'), this always works.
+  const updateManager = require('../lib/update-manager');
+
+  assert.equal(typeof updateManager.isMobilePlatform, 'function', 'isMobilePlatform should be a function');
+  assert.equal(typeof updateManager.getLatestRelease, 'function', 'getLatestRelease should be a function');
+  assert.equal(typeof updateManager.getManifestUrlFromRelease, 'function', 'getManifestUrlFromRelease should be a function');
+  assert.equal(typeof updateManager.compareVersions, 'function', 'compareVersions should be a function');
+  assert.equal(typeof updateManager.checkForUpdate, 'function', 'checkForUpdate should be a function');
+  assert.equal(typeof updateManager.initialize, 'function', 'initialize should be a function');
+});
+
+test('isMobilePlatform() returns false on server-side Node', () => {
+  const { isMobilePlatform } = require('../lib/update-manager');
+  assert.equal(isMobilePlatform(), false, 'Server-side module must always report non-mobile');
+});
+
+test('compareVersions handles edge cases', () => {
+  const { compareVersions } = require('../lib/update-manager');
+
+  assert.equal(compareVersions('1.0.0', '1.0.0'), 0, 'equal versions');
+  assert.equal(compareVersions('1.0.0', '2.0.0'), -1, 'v1 < v2');
+  assert.equal(compareVersions('2.0.0', '1.0.0'), 1, 'v1 > v2');
+  assert.equal(compareVersions('1.0.0', '1.0.1'), -1, 'patch difference');
+  assert.equal(compareVersions('0.4.19', '0.4.19'), 0, 'real version equality');
+});
+
+test('getManifestUrlFromRelease handles missing assets', () => {
+  const { getManifestUrlFromRelease } = require('../lib/update-manager');
+
+  assert.equal(getManifestUrlFromRelease(null), null, 'null release');
+  assert.equal(getManifestUrlFromRelease({}), null, 'no assets');
+  assert.equal(getManifestUrlFromRelease({ assets: [] }), null, 'empty assets');
+});
+
+test('getManifestUrlFromRelease finds manifest asset', () => {
+  const { getManifestUrlFromRelease } = require('../lib/update-manager');
+
+  const release = {
+    assets: [
+      { name: 'app.apk', browser_download_url: 'https://example.com/app.apk' },
+      { name: 'update-manifest.json', browser_download_url: 'https://example.com/manifest.json' },
+    ],
+  };
+
+  const url = getManifestUrlFromRelease(release);
+  assert.equal(url, 'https://example.com/manifest.json');
+});


### PR DESCRIPTION
Fixes #635

## Changes

- **package.json**: Remove `typescript` from devDependencies — no `.ts` files or `tsconfig.json` exist in the project.
- **lib/update-manager.js**: Replace `require("@capacitor/core")` with `IS_MOBILE = false` constant. This is a server-side module that never runs on a native platform, so the Capacitor import was unnecessary.
- **lib/update-manager.js**: Fix `compareVersions` — `Number.isFinite("1")` returns `false`, so string parts were always mapped to 0. Now parses with `Number(n)` first.
- **tests/update-manager-node-only.test.js**: Add Node-only import test per issue #635 acceptance criterion. Verifies the module imports without `@capacitor/core`, validates exported API, and tests compareVersions/getManifestUrlFromRelease edge cases.

## Testing

All 283 tests pass (was 277, added 6 new).

<!-- saffron-worker-footer -->
Worker: saffron-local
Model: litellm/nvidia