### PR TITLE
fix(release): wire post-deploy smoke into publish and manual release workflows

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -7,6 +7,10 @@ on:
         description: 'Release version (for example 0.4.15 or v0.4.15)'
         required: true
         type: string
+      deploy_url:
+        description: 'Deploy URL for post-deploy smoke check (e.g. https://miso-chat.example.com). Leave empty to skip.'
+        required: false
+        type: string
 
 concurrency:
   group: manual-release
@@ -92,3 +96,36 @@ jobs:
             --body "Version bump for release ${VERSION}. The release will be published after this PR passes the required checks and merges.")
           gh pr merge "$PR_URL" --auto --squash --delete-branch
           echo "Release PR: $PR_URL"
+
+  post-deploy-smoke:
+    needs: prepare-release
+    if: inputs.deploy_url != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout smoke script
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          sparse-checkout: scripts/post-deploy-smoke.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Wait for auto-merge and deployment
+        run: |
+          set -euo pipefail
+          echo "⏳ Waiting for release PR to merge and deployment to complete..."
+          # Give the auto-merge and publish-release workflow time to run
+          sleep 120
+
+      - name: Post-deploy smoke check
+        env:
+          SMOKE_BASE_URL: ${{ inputs.deploy_url }}
+          SMOKE_USERNAME: ${{ secrets.SMOKE_USERNAME }}
+          SMOKE_PASSWORD: ${{ secrets.SMOKE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          echo "🚀 Running post-deploy smoke against ${SMOKE_BASE_URL}"
+          if ! bash scripts/post-deploy-smoke.sh; then
+            echo "❌ Post-deploy smoke check FAILED"
+            exit 1
+          fi
+          echo "✅ Post-deploy smoke passed"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -125,3 +125,21 @@ jobs:
               --title "$VERSION" \
               --generate-notes
           fi
+
+      - name: Post-deploy smoke check
+        env:
+          SMOKE_BASE_URL: ${{ secrets.SMOKE_BASE_URL }}
+          SMOKE_USERNAME: ${{ secrets.SMOKE_USERNAME }}
+          SMOKE_PASSWORD: ${{ secrets.SMOKE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SMOKE_BASE_URL:-}" ]]; then
+            echo "ℹ️ SMOKE_BASE_URL not configured; skipping post-deploy smoke check"
+            exit 0
+          fi
+          echo "🚀 Running post-deploy smoke against ${SMOKE_BASE_URL}"
+          if ! bash scripts/post-deploy-smoke.sh; then
+            echo "❌ Post-deploy smoke check FAILED — release blocked"
+            exit 1
+          fi
+          echo "✅ Post-deploy smoke passed"


### PR DESCRIPTION
Fixes #639

Wire `scripts/post-deploy-smoke.sh` into both release workflows:

**publish-release.yml:**
- Added post-deploy smoke step after GitHub release creation
- Gated by `SMOKE_BASE_URL` secret — skips gracefully if not configured
- Fails the release workflow on smoke failure
- Also passes `SMOKE_USERNAME` and `SMOKE_PASSWORD` secrets for auth flows

**manual-release.yml:**
- Added optional `deploy_url` input for post-deploy smoke target
- New `post-deploy-smoke` job runs after auto-merge completes
- Includes wait period for deployment to finish before running smoke
- Fails the workflow on smoke failure

Both paths use the existing `scripts/post-deploy-smoke.sh` which checks:
1. Health endpoint (`/api/health`)
2. Login flow (if auth required)
3. Send-message API path

<!-- saffron-worker-footer -->
Worker: saffron-local
Model: litellm/nvidia