### PR TITLE
security: replace addImage innerHTML sink with createElement and add isSafeImageUrl guard

### DIFF
--- a/public/csp-hashes.json
+++ b/public/csp-hashes.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
-  "generatedAt": "2026-06-30T02:52:02.171Z",
+  "generatedAt": "2026-06-30T09:05:44.088Z",
   "algorithm": "sha256",
   "files": {
     "index.html": {
       "hashes": [
-        "'sha256-l6NmcUD8BgXrJGpRofoJPyupIrQIehGiEYwk2RKFS1U='"
+        "'sha256-QOchjouxxi9oDh5EM9osU1d08wHFuOM0KvDWzeOlO1k='"
       ],
       "blockCount": 1
     },

--- a/public/index.html
+++ b/public/index.html
@@ -3225,12 +3225,34 @@
         }
 
         
+        function isSafeImageUrl(url) {
+            try {
+                const parsed = new URL(url);
+                const protocol = parsed.protocol.toLowerCase();
+                if (protocol === 'http:' || protocol === 'https:') return true;
+                if (protocol === 'data:') {
+                    const lower = url.toLowerCase();
+                    return /^data:image\//.test(lower);
+                }
+                return false;
+            } catch {
+                return false;
+            }
+        }
+
     function addImage(url) {
+        if (!isSafeImageUrl(url)) return;
+
         const div = document.createElement('div'); div.className = 'message miso';
         const img = document.createElement('img'); img.src = url; img.loading = 'lazy';
         img.style.maxWidth = '100%'; img.style.borderRadius = '8px'; img.style.marginTop = '8px';
         img.onload = () => { messagesDiv.scrollTop = messagesDiv.scrollHeight; };
-        img.onerror = () => { div.innerHTML = '<a href="' + url + '" target="_blank" style="display:block;padding:12px;background:var(--bg-secondary);border-radius:8px;margin-top:8px;">View Image</a>'; div.querySelector('a').style.color = 'var(--accent)'; };
+        img.onerror = () => {
+            const a = document.createElement('a');
+            a.href = url; a.target = '_blank'; a.textContent = 'View Image';
+            a.style.cssText = 'display:block;padding:12px;background:var(--bg-secondary);border-radius:8px;margin-top:8px;color:var(--accent);';
+            div.appendChild(a);
+        };
         div.appendChild(img); messagesDiv.appendChild(div);
     }
 


### PR DESCRIPTION
Fixes #638

## Changes

- **Add `isSafeImageUrl(url)`** — validates image URLs by protocol:
  - Accepts `http:` and `https:`
  - Accepts `data:image/*` (image data URIs)
  - Rejects `javascript:`, non-image `data:`, and all other schemes
- **Guard `addImage()`** — early-return on unsafe URLs before any DOM manipulation
- **Replace innerHTML sink** — the `onerror` fallback now uses `createElement`/`setAttribute`/`textContent` instead of string-interpolated `innerHTML`, eliminating the XSS vector
- Regenerate CSP hash manifest for updated `index.html`

## Why

The `addImage` error handler interpolated a gateway-supplied URL into `innerHTML`. If a gateway response included a `javascript:` or crafted `data:` URL in its `images[]` array, the error fallback would execute it. The URL was not filtered to http(s) for `data.images` entries (unlike link-preview URLs).

All 298 tests pass.

<!-- saffron-worker-footer -->
Worker: saffron-local
Model: litellm/nvidia