### PR TITLE
docs: backfill changelog v0.4.14–v0.4.19, remove stale Capgo Cloud refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,36 @@ manager.on('reconnect-failed', (err) => {
 
 ## Changelog
 
+### v0.4.19 (2026-06-23)
+- Restore shared session access
+
+### v0.4.18 (2026-06-23)
+- Restore frontend startup
+
+### v0.4.17 (2026-06-22)
+- Fix render-utils.js module not defined and Rocket Loader script conflict
+
+### v0.4.16 (2026-06-22)
+- Release pipeline: support publish recovery, recognize app PR authors, detect missing tags, avoid tag visibility race
+- Fix service worker serving stale HTML with old CSP headers
+- Fix invalid action SHAs in android-release workflow
+
+### v0.4.15 (2026-06-22)
+- Route manual-release through PR + auto-merge
+- Remove CSP nonce that blocks inline scripts
+- Commit missing JS files (present in Docker image but not git)
+- Automate protected releases
+
+### v0.4.14 (2026-06-16)
+- Harden mobile OTA manifest trust with validation
+- Add session/operation authorization boundary and route-level CSRF tokens
+- Consolidate update manager, remove stale APK logic
+- Add SESSION_COOKIE_DOMAIN env var for subdomain isolation
+- Repair release/docs drift (changelog + OTA docs)
+- Make lint actually run ESLint on server.js, lib/, and tests/
+- Add authorization/integration test matrix
+- Harden container runtime defaults
+
 ### v0.4.13 (2026-06-04)
 - Added release runbook to AGENTS.md
 - Updated `@capgo/capacitor-updater` 8.47.5 → 8.47.6

--- a/docs/OTA-UPDATES.md
+++ b/docs/OTA-UPDATES.md
@@ -25,7 +25,7 @@ The OTA update system allows the Miso Chat mobile app to check for and download 
 4. **CI/CD Pipeline** (`.github/workflows/android-release.yml`)
    - Automatic APK building on release
    - Update manifest generation
-   - Optional Capgo sync
+   - Update manifest generation
 
 ## Configuration
 
@@ -39,8 +39,7 @@ CAPGO_APP_ID=chat.openclaw.miso        # Unique app identifier
 CAPGO_UPDATE_METHOD=manual             # 'manual' or 'auto'
 CAPACITOR_UPDATE_CHANNEL=stable        # 'stable' or 'beta'
 
-# Optional: Capgo Cloud Integration
-CAPGO_API_KEY=your_capgo_api_key       # For cloud-based update distribution
+
 ```
 
 ### Capacitor Config
@@ -119,29 +118,14 @@ const result = await updateManager.initialize({
 
 ### Creating a New Release
 
-1. **Update version in `package.json`**:
-   ```json
-   {
-     "version": "1.2.0"
-   }
-   ```
+Releases use a two-step GitHub Actions pipeline: **Manual Release** → **Publish Release**.
 
-2. **Create and push a Git tag**:
-   ```bash
-   git tag v1.2.0
-   git push origin v1.2.0
-   ```
+1. Navigate to **Actions → Manual Release → Run workflow**.
+2. Enter the target version (e.g. `0.4.20` or `v0.4.20`). The workflow normalizes the prefix, opens a version-bump PR, and enables auto-merge.
+3. After required checks pass, the PR merges automatically.
+4. **Publish Release** triggers on merge: it tags the merge commit and creates the GitHub release with generated notes.
 
-3. **Create a GitHub Release**:
-   - Go to GitHub Releases
-   - Create new release with tag `v1.2.0`
-   - Add release notes
-   - Publish release
-
-4. **Automatic Actions**:
-   - CI/CD builds the APK
-   - Update manifest is generated
-   - APK and manifest are uploaded to the release
+The `update-manifest.json` is served from the latest GitHub release via `GET /api/mobile/update-manifest`.
 
 ### Update Manifest Format
 
@@ -165,23 +149,6 @@ const result = await updateManager.initialize({
   }
 }
 ```
-
-## Capgo Cloud Integration (Optional)
-
-For enhanced update distribution, you can optionally integrate with Capgo's cloud service:
-
-1. **Create a Capgo account** at https://capgo.app
-
-2. **Get your API key** from the Capgo dashboard
-
-3. **Add secrets to GitHub**:
-   - `CAPGO_API_KEY`: Your Capgo API key
-   - `CAPGO_APP_ID`: Your Capgo app ID (optional, defaults to `chat.openclaw.miso`)
-
-4. **The CI/CD pipeline will automatically**:
-   - Upload new bundles to Capgo
-   - Manage update channels
-   - Provide analytics on update adoption
 
 ## Update Channels
 


### PR DESCRIPTION
Fixes #636

Backfill README changelog through v0.4.19 (was stopped at v0.4.13), remove stale `CAPGO_API_KEY` and Capgo Cloud references from `docs/OTA-UPDATES.md`, and align the release workflow documentation with the current `manual-release.yml` → `publish-release.yml` pipeline.

**Changelog backfill:**
- v0.4.19: restore shared session access
- v0.4.18: restore frontend startup
- v0.4.17: fix render-utils.js module not defined + Rocket Loader conflict
- v0.4.16: release pipeline fixes, service worker CSP fix, android-release workflow fix
- v0.4.15: manual-release PR+auto-merge route, CSP nonce removal, missing JS files committed, protected releases automation
- v0.4.14: OTA manifest validation, CSRF tokens, update manager consolidation, ESLint fix, auth/integration tests, container runtime hardening

**OTA docs cleanup:**
- Removed `CAPGO_API_KEY` env var (no longer used)
- Removed "Capgo Cloud Integration (Optional)" section
- Replaced manual git tag + release instructions with current Manual Release → Publish Release workflow

<!-- saffron-worker-footer -->
Worker: saffron-local
Model: litellm/nvidia